### PR TITLE
Silence DEBUG level statements by default in the build phase

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d [%t] %-5p %c - %m%n</pattern>
+    </encoder>
+  </appender>
+  <root level="INFO">
+    <appender-ref ref="stdout"/>
+  </root>
+</configuration>


### PR DESCRIPTION
While reviewing #3, I realized that the build of this component was very verbose (in Travis or Jenkins CI). This is largely due to the `DEBUG` level statements in the `generate-sources` phase.

This commit attempts to reduce this verbosity by defining a default `logback.xml` under `src/main/resources` setting the root debug level at `INFO`.
Nothing should be affected by this change and the Travis logs should no longer exceed the 10000 lines limit (see https://travis-ci.org/ome/bio-formats-documentation/jobs/349237895).

In a future cleanup step, some of the `println` statements in the `generated-sources` classes could be replaced by proper invocations of the logger at the INFO level.