### PR TITLE
Update for bioformats 5.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>bio-formats-documentation</artifactId>
-  <version>5.8.1-SNAPSHOT</version>
+  <version>5.8.1</version>
 
   <name>Bio-Formats documentation</name>
   <description>Bio-Formats Sphinx documentation</description>
@@ -25,7 +25,7 @@
   <properties>
     <ome-common.version>5.3.2</ome-common.version>
     <ome-model.version>5.5.4</ome-model.version>
-    <bioformats.version>5.8.1-SNAPSHOT</bioformats.version>
+    <bioformats.version>5.8.1</bioformats.version>
     <logback.version>1.1.1</logback.version>
 
     <sphinx.bioformats.source.branch>develop</sphinx.bioformats.source.branch>

--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -1,6 +1,39 @@
 Version history
 ===============
 
+5.8.1 (2018 March 22)
+---------------------
+
+File format fixes and improvements:
+
+* TIFF
+   - updated TiffWriter so that planes will no longer be split when using non-standard
+     SamplesPerPixel e.g. images with 2 or 4 samples per pixel. This will ensure the ``TiffData``
+     elements represent the structure specified by the user. If users wish to split planes the 
+     ``ChannelSeparator`` and ``bfconvert`` provide the means to do this explicitly
+   - updated TiffWriter to use the correct logic for index checking when writing tiled images
+   - fixed a ``ClassCastException`` when the ``NEW_SUBFILE_TYPE`` tag has a non-standard type
+     or count such that the value is not inlined
+   - updated to also check the last IFD for an ImageJ comment in the scenario that the image has 
+     been processed by other software
+* NRRD (Nearly Raw Raster Data)
+   - added support for ``space directions`` and ``space units`` fields added in version 4
+* Evotec/PerkinElmer Opera Flex
+   - updated to read rather than calculate image offsets when a single tile is used
+
+Bug fixes and improvements:
+
+* limited the number of exceptions in the Bio-Formats plugins exporter when an unsupported pixel 
+  type is found
+* fake test images now allow for per-plane ExposureTime{X,Y,Z} and Position{X,Y,Z} keys in the INI file
+  (for further details see the documentation for :doc:`Generating test images </developers/generating-test-images>`)
+* file patterns now have expanded support for multi-channel pyramids, allowing for the matching of 
+  at least two channels rather than three, and the stitching of files containing a pyramid has also been fixed
+
+Documentation improvements:
+
+* improved testing of external links
+
 5.8.0 (2018 February 21)
 ------------------------
 

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -368,10 +368,16 @@ linkcheck_timeout = int(os.environ.get("SPHINX_LINKCHECK_TIMEOUT", 30))
 linkcheck_workers = int(os.environ.get("SPHINX_LINKCHECK_WORKERS", 5))
 linkcheck_retries = int(os.environ.get("SPHINX_LINKCHECK_RETRIES", 5))
 
+# Timeout value, in seconds, for the linkcheck builder
+linkcheck_timeout = int(os.environ.get("SPHINX_LINKCHECK_TIMEOUT", 30))
+linkcheck_workers = int(os.environ.get("SPHINX_LINKCHECK_WORKERS", 5))
+linkcheck_retries = int(os.environ.get("SPHINX_LINKCHECK_RETRIES", 5))
+
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
 linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     'https://www.olympus-global.com',
     'http://www.lavisionbiotec.com/',
-    r'http://mdbtools.cvs.sourceforge.net/.*',
+    r'.*[.]sourceforge.net',
+    r'http://www.libpng.org/.*',
     'https://nifti.nimh.nih.gov/nifti-1/'
 ]

--- a/sphinx/developers/generating-test-images.rst
+++ b/sphinx/developers/generating-test-images.rst
@@ -39,6 +39,21 @@ global metadata map:
     echo "[GlobalMetadata]" >> my-special-test-file.fake.ini
     echo "my.key=some.value" >> my-special-test-file.fake.ini
 
+The :file:`.ini` file can also contain one section for each series, which allows metadata such as
+exposure times and positions to be set for each plane:
+
+::
+
+    echo "[series_0]" >> my-special-test-file.fake.ini
+    echo "ExposureTime_0=10" >> my-special-test-file.fake.ini
+    echo "ExposureTimeUnit_0=ms" >> my-special-test-file.fake.ini
+    echo "PositionX_0=5" >> my-special-test-file.fake.ini
+    echo "PositionY_0=-5" >> my-special-test-file.fake.ini
+    echo "PositionZ_0=1" >> my-special-test-file.fake.ini
+    echo "PositionXUnit_0=mm" >> my-special-test-file.fake.ini
+    echo "PositionYUnit_0=mm" >> my-special-test-file.fake.ini
+    echo "PositionZUnit_0=mm" >> my-special-test-file.fake.ini
+
 
 Several keys have support for units and can be expressed as ``KEY=VALUE UNIT`` where ``UNIT`` is the symbol of the desired unit::
 
@@ -228,10 +243,37 @@ with their default values, is shown below.
     - * ellipses, labels, lines, points, polygons, polylines, rectangles
       * the number of ROIs containing one shape of the given type to generate
       *
+    - * ExposureTime_x
+      * floating point exposure time for plane ``x`` [2]_
+      *
+    - * ExposureTimeUnit_x
+      * string defining the units for the corresponding ``ExposureTime_x`` [2]_
+      * seconds
+    - * PositionX_x
+      * floating point X position for plane ``x`` [2]_
+      *
+    - * PositionXUnit_x
+      * string defining the units for the corresponding ``PositionX_x`` [2]_
+      * microns
+    - * PositionY_x
+      * floating point Y position for plane ``x`` [2]_
+      *
+    - * PositionYUnit_x
+      * string defining the units for the corresponding ``PositionY_x`` [2]_
+      * microns
+    - * PositionZ_x
+      * floating point Z position for plane ``x`` [2]_
+      *
+    - * PositionZUnit_x
+      * string defining the units for the corresponding ``PositionZ_x`` [2]_
+      * microns
+
 
 .. [1] Default value set to 1 if any of the ``screens``, ``plates``,
        ``plateAcqs``, ``plateRows``, ``plateCols`` or ``fields`` values is set
        to a value greater than zero.
+
+.. [2] Must be stored in the INI file under a ``[series_n]`` section, where ``n`` is the 0-based series index.
 
 For full details of these keys, how unset and default values are handled and
 further examples see :source:`loci.formats.in.FakeReader <components/formats-bsd/src/loci/formats/in/FakeReader.java>`.


### PR DESCRIPTION
This is the state of the documentation kept in sync with the bioformats 5.8.1 release (or, rather, the untagged `87acd820` which included the final docs updates).  It should also be tagged (but not released), to mark this point in the history.  This brings it up to date with the documentation changes made between `v5.8.0` and `v5.9.0`/`87acd820`