### PR TITLE
build: Disable hard failure for linkchecking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -534,7 +534,6 @@
                     <argument>${sphinx_builddir}/cache</argument>
                     <argument>-b</argument>
                     <argument>${sphinx.linkchecker}</argument>
-                    <argument>-W</argument>
                     <argument>${sphinx_builddir}</argument>
                     <argument>${sphinx_builddir}/${sphinx.linkchecker}</argument>
                   </arguments>


### PR DESCRIPTION
Maven won't allow this to be a configurable property (`-W`), so remove until we adopt gradle.  This will make the CI jobs succeed if the linkchecking fails.  It will require extra job logic to scan the logs for broken links.