### PR TITLE
Add ome_model.uri property to configure location of ome-model documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,12 @@
     <sphinx.ome_source.user>ome</sphinx.ome_source.user>
     <sphinx.openmicroscopy_source.user>openmicroscopy</sphinx.openmicroscopy_source.user>
 
+    <ome-model.uri>https://docs.openmicroscopy.org/ome-model/${ome-model.version}</ome-model.uri>
+
     <!-- Sphinx variable filtering -->
     <ome_common_version>${ome-common.version}</ome_common_version>
     <ome_model_version>${ome-model.version}</ome_model_version>
+    <ome_model_uri>${ome-model.uri}</ome_model_uri>
     <bioformats_source_branch>${sphinx.bioformats.source.branch}</bioformats_source_branch>
     <ome_source_user>${sphinx.ome_source.user}</ome_source_user>
     <openmicroscopy_source_user>${sphinx.openmicroscopy_source.user}</openmicroscopy_source_user>

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -19,6 +19,7 @@ openmicroscopy_source_user = '@openmicroscopy_source_user@'
 ome_source_user = '@ome_source_user@'
 ome_common_version = '@ome_common_version@'
 ome_model_version = '@ome_model_version@'
+ome_model_uri = '@ome_model_uri@'
 
 import sys, os
 sys.path.insert(0, os.path.abspath(os.path.join(srcdir, '_ext')))
@@ -159,6 +160,9 @@ extlinks = {
     'schema' : (oo_root + '/Schemas/Documentation/Generated/%s', ''),
     'examples' : (github_root + 'openmicroscopy/bio-formats-examples/blob/master/%s', ''),
     }
+
+if ome_model_uri != "":
+    extlinks['model_doc'] = (ome_model_uri + '/' + '%s', '')
 
 rst_epilog = """
 .. _Hibernate: http://www.hibernate.org


### PR DESCRIPTION
Testing: will be tested on east-ci which will set the property.