### PR TITLE
Add fei.com to ignore list

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -381,5 +381,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'.*[.]sourceforge.net',
     r'http://www.libpng.org/.*',
     'https://nifti.nimh.nih.gov/nifti-1/',
-    r'https://cbia.fi.muni.cz.*'
+    r'https://cbia.fi.muni.cz.*',
+    r'https://www.fei.com/.*'
 ]


### PR DESCRIPTION
This is a follow up to https://github.com/ome/bio-formats-documentation/pull/17
Adding fei.com to the ignore list based on failed builds: https://web-proxy.openmicroscopy.org/west-ci/job/BIOFORMATS-docs/5/consoleFull
