### PR TITLE
Bump version to 5.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>bio-formats-documentation</artifactId>
-  <version>5.8.2-rc1</version>
+  <version>5.8.2</version>
 
   <name>Bio-Formats documentation</name>
   <description>Bio-Formats Sphinx documentation</description>
@@ -25,8 +25,8 @@
   <properties>
     <ome-common.version>5.3.2</ome-common.version>
     <ome-model.version>5.5.4</ome-model.version>
-    <bioformats.version>5.8.2-rc1</bioformats.version>
-    <bio-formats-examples.version>5.8.2-rc1</bio-formats-examples.version>
+    <bioformats.version>5.8.2</bioformats.version>
+    <bio-formats-examples.version>5.8.2</bio-formats-examples.version>
     <logback.version>1.1.1</logback.version>
 
     <sphinx.bioformats.source.branch>develop</sphinx.bioformats.source.branch>


### PR DESCRIPTION
Bumping version to 5.8.2 as part of https://trello.com/c/1c450ijt/29-release-bio-formats-documentation-component