### PR TITLE
Update public format page for Vectra QPTIFF format

### DIFF
--- a/docs/sphinx/.gitignore
+++ b/docs/sphinx/.gitignore
@@ -1,3 +1,0 @@
-_build
-venv
-conf.py

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -1975,7 +1975,9 @@ Commercial applications that support this format include: \n
 extensions = .tif, .qptiff
 owner = `PerkinElmer <http://www.perkinelmer.com/>`_
 bsd = no
-weHave = * a specification document
+pyramid = yes
+weHave = * a `specification document <http://downloads.openmicroscopy.org/images/Vectra-QPTIFF/perkinelmer/PKI_Image%20Format.docx>`__\n
+* `public sample images <http://downloads.openmicroscopy.org/images/Vectra-QPTIFF/>`__\n
 * several datasets
 pixelsRating = Very good
 metadataRating = Outstanding


### PR DESCRIPTION
See https://docs.openmicroscopy.org/bio-formats/5.8.2/formats/perkinelmer-vectra-qptiff.html

This updates the Vectra QPTIFF format page to:
- mention the pyramid support
- add references to the public specification and sample images


2028690 also removes a single `.gitignore` file in the legacy `docs/sphinx` folder (pre-decoupling).

/cc @melissalinkert 