### PR TITLE
Add license/copyright section to about page

### DIFF
--- a/sphinx/about/index.rst
+++ b/sphinx/about/index.rst
@@ -31,7 +31,9 @@ Copyright (C) 2005 - 2018 Open Microscopy Environment:
 
 Bio-Formats can be cited in publications as follows:
 
-`Melissa Linkert, Curtis T. Rueden, Chris Allan, Jean-Marie Burel, Will Moore, Andrew Patterson, Brian Loranger, Josh Moore, Carlos Neves, Donald MacDonald, Aleksandra Tarkowska, Caitlin Sticco, Emma Hill, Mike Rossner, Kevin W. Eliceiri, and Jason R. Swedlow (2010) Metadata matters: access to image data in the real world. The Journal of Cell Biology 189(5), 777-782. doi: 10.1083/jcb.201004104 <http://www.ncbi.nlm.nih.gov/pubmed/20513764>`_
+  Melissa Linkert, Curtis T. Rueden, Chris Allan, Jean-Marie Burel, Will Moore, Andrew Patterson, Brian Loranger, Josh Moore, Carlos Neves, Donald MacDonald, Aleksandra Tarkowska, Caitlin Sticco, Emma Hill, Mike Rossner, Kevin W. Eliceiri, and Jason R. Swedlow (2010) Metadata matters: access to image data in the real world. The Journal of Cell Biology 189(5), 777-782. doi: 10.1083/jcb.201004104
+
+`PMID:20513764 <http://www.ncbi.nlm.nih.gov/pubmed/20513764>`_
 
 Additional citation information can be found on the :oo_root:`main OME citation page <citing-ome>`.
 

--- a/sphinx/about/index.rst
+++ b/sphinx/about/index.rst
@@ -18,6 +18,17 @@ structure is of vital importance to the community. You may find LOCI's article
 on `open source software in
 science <http://loci.wisc.edu/software/oss>`_ of interest.
 
+License and copyright
+---------------------
+
+Licensing information for Bio-Formats is described on :oo_root:`the OME licensing page <licensing>`.
+Unless otherwise noted, the current copyright statement is:
+
+Copyright (C) 2005 - 2018 Open Microscopy Environment:
+      - Board of Regents of the University of Wisconsin-Madison
+      - Glencoe Software, Inc.
+      - University of Dundee
+
 Help
 ----
 

--- a/sphinx/about/index.rst
+++ b/sphinx/about/index.rst
@@ -18,8 +18,8 @@ structure is of vital importance to the community. You may find LOCI's article
 on `open source software in
 science <http://loci.wisc.edu/software/oss>`_ of interest.
 
-License and copyright
----------------------
+License, copyright, and citation
+--------------------------------
 
 Licensing information for Bio-Formats is described on :oo_root:`the OME licensing page <licensing>`.
 Unless otherwise noted, the current copyright statement is:
@@ -28,6 +28,12 @@ Copyright (C) 2005 - 2018 Open Microscopy Environment:
       - Board of Regents of the University of Wisconsin-Madison
       - Glencoe Software, Inc.
       - University of Dundee
+
+Bio-Formats can be cited in publications as follows:
+
+`Melissa Linkert, Curtis T. Rueden, Chris Allan, Jean-Marie Burel, Will Moore, Andrew Patterson, Brian Loranger, Josh Moore, Carlos Neves, Donald MacDonald, Aleksandra Tarkowska, Caitlin Sticco, Emma Hill, Mike Rossner, Kevin W. Eliceiri, and Jason R. Swedlow (2010) Metadata matters: access to image data in the real world. The Journal of Cell Biology 189(5), 777-782. doi: 10.1083/jcb.201004104 <http://www.ncbi.nlm.nih.gov/pubmed/20513764>`_
+
+Additional citation information can be found on the :oo_root:`main OME citation page <citing-ome>`.
 
 Help
 ----

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -143,6 +143,7 @@ extlinks = {
     'forum' : (oo_root + '/community/%s', ''),
     # Website links. Separating them out so that we can add prefixes and
     # suffixes during testing.
+    'oo_root' : (oo_root + '/%s', ''),
     'community' : (oo_root + '/support/%s', ''),
     'omero' : (oo_root + '/omero/%s', ''),
     # Documentation


### PR DESCRIPTION
This makes the license and current copyright easier to find, especially for anyone who uses Bio-Formats but doesn't read the code.

I'm not necessarily attached to the change in 968127a, so happy to revert if it's a problem or there is a better way to link to https://www.openmicroscopy.org/licensing/