### PR TITLE
Remove Java 7 from Appveyor configuration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,6 @@ environment:
   matrix:
     - java: 9
     - java: 1.8
-    - java: 1.7
 
 cache:
   - '%AV_OME_M2% -> appveyor.yml'
@@ -22,7 +21,6 @@ platform: x64
 init:
   - git config --global core.autocrlf input
   - refreshenv
-  - 'if [%java%] == [1.7] set "JAVA_HOME=C:\Program Files\Java\jdk1.7.0"'
   - 'if [%java%] == [1.8] set "JAVA_HOME=C:\Program Files\Java\jdk1.8.0"'
   - 'if [%java%] == [9] set "JAVA_HOME=C:\Program Files\Java\jdk9"'
   - PATH=%JAVA_HOME%\bin;%PATH%


### PR DESCRIPTION
See  https://central.sonatype.org/articles/2018/May/04/discontinue-support-for-tlsv11-and-below/ and https://github.com/openmicroscopy/bioformats/pull/3174 for more details