### PR TITLE
Fix link to Glencoe Software press release

### DIFF
--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -686,7 +686,7 @@ File format fixes:
 New features/API:
 
 * added support for JPEG-XR compressed CZI data (funded by a
-  `partnership between Glencoe Software and ZEISS <http://glencoesoftware.com/2016-08-30-glencoe-software-zeiss-partner-open-source-file-reader-whole-slide.html>`_), adding 'ome:jxrlib' as a new dependency
+  `partnership between Glencoe Software and ZEISS <http://glencoesoftware.com/pressreleases/2016-08-30-glencoe-software-zeiss-partner-open-source-file-reader-whole-slide.html>`_), adding 'ome:jxrlib' as a new dependency
   of Bio-Formats
 * improved tile-based image writing
     - added new methods to the ``loci.formats.IFormatWriter`` interface


### PR DESCRIPTION
Following the recent overhaul of the Glencoe website, the link to the original press release for the Zeiss CZI work has been modified. This updates the documentation to use the new `pressreleases/` URL instead.

With this, https://web-proxy.openmicroscopy.org/west-ci/job/BIOFORMATS-docs/ should turn green.