### PR TITLE
Update link to i3dcore

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -386,5 +386,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'.*[.]sourceforge.net',
     r'http://www.libpng.org/.*',
     'https://nifti.nimh.nih.gov/nifti-1/',
+    r'https://cbia.fi.muni.cz.*',
     r'https://www.fei.com/.*'
 ]

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -386,6 +386,5 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'.*[.]sourceforge.net',
     r'http://www.libpng.org/.*',
     'https://nifti.nimh.nih.gov/nifti-1/',
-    r'https://cbia.fi.muni.cz.*',
     r'https://www.fei.com/.*'
 ]

--- a/sphinx/users/i3dcore/index.rst
+++ b/sphinx/users/i3dcore/index.rst
@@ -1,7 +1,7 @@
 i3dcore
 =======
 
-`i3dcore <https://cbia.fi.muni.cz/software/>`_,
+`i3dcore <https://cbia.fi.muni.cz/software/i3d-library.html>`_,
 also known as the CBIA 3D image representation library, is a 3D image
 processing library developed at the `Centre for Biomedical Image
 Analysis <https://cbia.fi.muni.cz>`_. Together


### PR DESCRIPTION
See https://trello.com/c/lvf099f3/234-i3dcore-cbia-3d-library-status.  i3d seems to have its own page on the CBIA website again, so it's now linked directly.  