### PR TITLE
Update the link to www.slidebook.com

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -26,7 +26,7 @@ https://www.intelligent-imaging.com/slidebook.\n
 http://www.openmicroscopy.org/info/slidebook for details.\n
 \n
 .. seealso:: \n
-  `Slidebook software overview <https://www.intelligent-imaging.com/slidebook`_ \n
+  `Slidebook software overview <https://www.intelligent-imaging.com/slidebook>`_ \n
 \n
 .. _Intelligent Imaging Innovations: http://www.intelligent-imaging.com/
 

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -26,7 +26,7 @@ https://www.intelligent-imaging.com/slidebook.\n
 http://www.openmicroscopy.org/info/slidebook for details.\n
 \n
 .. seealso:: \n
-  `Slidebook software overview <https://www.slidebook.com>`_ \n
+  `Slidebook software overview <https://www.intelligent-imaging.com/slidebook`_ \n
 \n
 .. _Intelligent Imaging Innovations: http://www.intelligent-imaging.com/
 


### PR DESCRIPTION
The SSL certificate has expired (causing the linkcheck to fail) and this page is moved permanently to the 3i website.
