### PR TITLE
Permanent redirects

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -159,7 +159,7 @@ extlinks = {
     # Miscellaneous links
     'doi' : ('http://dx.doi.org/%s', ''),
     'schema' : (oo_root + '/Schemas/Documentation/Generated/%s', ''),
-    'examples' : (github_root + 'openmicroscopy/bio-formats-examples/blob/master/%s', ''),
+    'examples' : (github_root + 'ome/bio-formats-examples/blob/master/%s', ''),
     }
 
 if ome_model_uri != "":

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -387,5 +387,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'http://www.libpng.org/.*',
     'https://nifti.nimh.nih.gov/nifti-1/',
     r'https://cbia.fi.muni.cz.*',
-    r'https://www.fei.com/.*'
+    r'https://www.fei.com/.*',
+    'https://animatedpngs.com/', # SSL certificate error
 ]

--- a/sphinx/developers/components.rst
+++ b/sphinx/developers/components.rst
@@ -39,7 +39,7 @@ All components
 
 .. _bio-formats-plugins:
 
-:source:`bio-formats-plugins (Bio-Formats Plugins for ImageJ) <components/bio-formats-plugins>`:
+:sourcedir:`bio-formats-plugins (Bio-Formats Plugins for ImageJ) <components/bio-formats-plugins>`:
 
 `Ant: jar-bio-formats-plugins`
 
@@ -50,7 +50,7 @@ be in keeping with ImageJ plugin naming conventions.
 
 .. _bio-formats-tools:
 
-:source:`bio-formats-tools (Bio-Formats command line tools) <components/bio-formats-tools>`:
+:sourcedir:`bio-formats-tools (Bio-Formats command line tools) <components/bio-formats-tools>`:
 
 `Ant: jar-bio-formats-tools`
 
@@ -62,7 +62,7 @@ target (which is the Ant equivalent of :ref:`bundles <bundles>`).
 
 .. _bundles:
 
-:source:`bundles (bioformats_package bundle, LOCI Tools bundle) <components/bundles>`:
+:sourcedir:`bundles (bioformats_package bundle, LOCI Tools bundle) <components/bundles>`:
 
 `Ant: tools`
 
@@ -89,7 +89,7 @@ need to remove the conflicting JAR(s) as a workaround.
 
 .. _forks-turbojpeg:
 
-:source:`forks/turbojpeg (libjpeg-turbo Java bindings) <components/forks/turbojpeg>`:
+:sourcedir:`forks/turbojpeg (libjpeg-turbo Java bindings) <components/forks/turbojpeg>`:
 
 `Ant: jar-turbojpeg`
 
@@ -102,7 +102,7 @@ on other components.
 
 .. _formats-api:
 
-:source:`formats-api (Bio-Formats API) <components/formats-api>`:
+:sourcedir:`formats-api (Bio-Formats API) <components/formats-api>`:
 
 `Ant: jar-formats-api`
 
@@ -116,7 +116,7 @@ readers and writers. :ref:`ome-common <ome-common>` and
 
 .. _formats-bsd:
 
-:source:`formats-bsd (BSD Bio-Formats readers and writers) <components/formats-bsd>`:
+:sourcedir:`formats-bsd (BSD Bio-Formats readers and writers) <components/formats-bsd>`:
 
 `Ant: jar-formats-bsd`
 
@@ -125,7 +125,7 @@ specification, e.g. TIFF.  Everything in the component is BSD-licensed.
 
 .. _formats-gpl:
 
-:source:`formats-gpl (Bio-Formats library) <components/formats-gpl>`:
+:sourcedir:`formats-gpl (Bio-Formats library) <components/formats-gpl>`:
 
 `Ant: jar-formats-gpl`
 
@@ -138,7 +138,7 @@ available specification.
 
 .. _test-suite:
 
-:source:`test-suite (Bio-Formats testing framework) <components/test-suite>`:
+:sourcedir:`test-suite (Bio-Formats testing framework) <components/test-suite>`:
 
 `Ant: jar-tests`
 

--- a/sphinx/developers/components.rst
+++ b/sphinx/developers/components.rst
@@ -229,7 +229,7 @@ allows OLE files to be read from memory.
 `Metakit Java library <https://github.com/ome/ome-metakit/tree/master>`_:
 
 Java implementation of the `Metakit database specification
-<http://equi4.com/metakit/>`_.  This uses classes from
+<https://equi4.com/metakit/>`_.  This uses classes from
 :ref:`ome-common <ome-common>` and is used by
 :ref:`formats-gpl <formats-gpl>`, but is otherwise independent of the main
 Bio-Formats API.

--- a/sphinx/developers/java-library.rst
+++ b/sphinx/developers/java-library.rst
@@ -90,7 +90,7 @@ The complete list of current dependencies is as follows:
     * - `Joda time v2.2 <https://github.com/JodaOrg/joda-time>`_
       - joda-time:joda-time:2.2
       - `Apache License v2.0`_
-    * - `JUnit v4.10 <http://junit.org>`_
+    * - `JUnit v4.10 <https://junit.org/junit4/>`_
       - junit:junit:4.10
       - `Common Public License v1.0`_
     * - `Apache Log4j v1.2.17 <http://logging.apache.org/log4j/1.2>`_

--- a/sphinx/developers/java-library.rst
+++ b/sphinx/developers/java-library.rst
@@ -12,7 +12,7 @@ enable the use of this repository.
 
 Examples of getting started with Bio-Formats using Maven or Gradle are given
 in the https://github.com/ome/bio-formats-examples repository.
-`OMERO <http://github.com/openmicroscopy/openmicroscopy>`_ uses Ivy to manage
+`OMERO <https://github.com/openmicroscopy/openmicroscopy>`_ uses Ivy to manage
 its Java dependencies including Bio-Formats.
 
 .. note::

--- a/sphinx/developers/java-library.rst
+++ b/sphinx/developers/java-library.rst
@@ -11,7 +11,7 @@ snippets for inclusion into your Gradle, Maven or Ivy project, which will
 enable the use of this repository.
 
 Examples of getting started with Bio-Formats using Maven or Gradle are given
-in the https://github.com/openmicroscopy/bio-formats-examples repository.
+in the https://github.com/ome/bio-formats-examples repository.
 `OMERO <http://github.com/openmicroscopy/openmicroscopy>`_ uses Ivy to manage
 its Java dependencies including Bio-Formats.
 

--- a/sphinx/developers/python-dev.rst
+++ b/sphinx/developers/python-dev.rst
@@ -10,5 +10,5 @@ using `pip`::
   pip install python-bioformats
 
 .. seealso::
-   https://pypi.python.org/pypi/python-bioformats
+   https://pypi.org/pypi/python-bioformats
       Source code of the CellProfiler Python wrapper for Bio-Formats

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -1071,7 +1071,7 @@ reader = IonpathMIBITiffReader
 [IVision]
 pagename = iplab-mac
 extensions = .ipm
-owner = `BioVision Technologies <http://biovis.com/>`_
+owner = `BioVision Technologies <https://www.biovis.com/>`_
 bsd = no
 weHave = * a few iVision-Mac datasets\n
 * a specification document
@@ -1087,7 +1087,7 @@ notes = iVision-Mac was formerly called IPLab for Macintosh.
 
 [IPLab]
 extensions = .ipl
-owner = was `BD Biosystems <http://www.bdbiosciences.com/>`_, now `BioVision Technologies <http://www.biovis.com/iplab.htm>`_
+owner = was `BD Biosystems <http://www.bdbiosciences.com/>`_, now `BioVision Technologies <https://www.biovis.com/iplab.htm>`_
 developer = Scanalytics
 bsd = no
 software = `IPLab Reader plugin for ImageJ <https://imagej.nih.gov/ij/plugins/iplab-reader.html>`_
@@ -1107,7 +1107,7 @@ notes = Commercial applications that support IPLab include: \n
 * `SVI Huygens <http://svi.nl/>`_ \n
 \n
 .. seealso:: \n
-  `IPLab software review <http://www.biovis.com/iplab.htm>`_
+  `IPLab software review <https://www.biovis.com/iplab.htm>`_
 
 [JEOL]
 extensions = .dat, .img, .par

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -62,7 +62,7 @@ reader = AIMReader
 
 [Alicona 3D]
 extensions = .al3d
-owner = `Alicona Imaging <http://www.alicona.com/>`_
+owner = `Alicona Imaging <https://www.alicona.com/>`_
 bsd = no
 versions = 1.0
 weHave = * an AL3D specification document (v1.0, from 2003, in PDF)\n
@@ -125,7 +125,7 @@ reader = AmiraReader
 
 [Analyze 7.5]
 extensions = .img, .hdr
-developer = `Mayo Foundation Biomedical Imaging Resource <http://www.mayo.edu/research/core-resources/biomedical-imaging-resource-core/overview>`_
+developer = `Mayo Foundation Biomedical Imaging Resource <https://www.mayo.edu/research/core-resources/biomedical-imaging-resource-core/overview>`_
 bsd = no
 weHave = * `an Analyze 7.5 specification document <http://web.archive.org/web/20070927191351/http://www.mayo.edu/bir/PDF/ANALYZE75.pdf>`_ \n
 * several Analyze 7.5 datasets
@@ -171,9 +171,9 @@ reader = SIFReader
 
 [Animated PNG]
 extensions = .png
-developer = `The Animated PNG Project <https://www.animatedpng.com/>`_
+developer = `The Animated PNG Project <https://animatedpngs.com/>`_
 bsd = yes
-software = `Firefox 3+ <https://www.mozilla.com/en-US/firefox>`_ \n
+software = `Firefox 3+ <https://www.mozilla.org/en-US/firefox>`_ \n
 `Opera 9.5+ <http://www.opera.com>`_ \n
 `KSquirrel <http://ksquirrel.sourceforge.net/download.php>`_
 weHave = * `a specification document <http://wiki.mozilla.org/APNG_Specification>`_ \n
@@ -245,8 +245,8 @@ pagename = avi
 extensions = .avi
 developer = `Microsoft <http://www.microsoft.com/>`_
 bsd = yes
-software = `AVI Reader plugin for ImageJ <https://rsb.info.nih.gov/ij/plugins/avi-reader.html>`_ \n
-`AVI Writer plugin for ImageJ <https://rsb.info.nih.gov/ij/plugins/avi.html>`_
+software = `AVI Reader plugin for ImageJ <https://imagej.nih.gov/ij/plugins/avi-reader.html>`_ \n
+`AVI Writer plugin for ImageJ <https://imagej.nih.gov/ij/plugins/avi.html>`_
 weHave = * several AVI datasets
 weWant = * more AVI datasets, including: \n
 \n
@@ -303,9 +303,9 @@ mif = true
 [Becker & Hickl SPC FIFO]
 pagename = becker-hickl-fifo
 extensions = .spc
-owner = `Becker-Hickl <http://www.becker-hickl.de/>`_
+owner = `Becker-Hickl <https://www.becker-hickl.com/>`_
 bsd = no
-weHave = * an `SPC specification document <http://www.becker-hickl.com/handbookphp.htm>`_ \n
+weHave = * an `SPC specification document <https://www.becker-hickl.com/handbookphp.htm>`_ \n
 * `public sample images <http://downloads.openmicroscopy.org/images/SPC-FIFO/>`__
 weWant = * more SPC sample files
 pixelsRating = Poor
@@ -320,11 +320,11 @@ notes = * Only files containing frame, line and pixel clock information \n
 
 [Becker & Hickl SPCImage]
 extensions = .sdt
-owner = `Becker-Hickl <http://www.becker-hickl.de/>`_
+owner = `Becker-Hickl <https://www.becker-hickl.com/>`_
 bsd = no
 weHave = * an SDT specification document (from 2008 April, in PDF) \n
 * an SDT specification document (from 2006 June, in PDF) \n
-* Becker & Hickl's `SPCImage <http://www.becker-hickl.de/software/tcspc/softwaretcspcspecial.htm>`_ software \n
+* Becker & Hickl's `SPCImage <https://www.becker-hickl.com/software/tcspc/softwaretcspcspecial.htm>`_ software \n
 * a large number of SDT datasets \n
 * the ability to produce new datasets
 pixelsRating = Very good
@@ -457,9 +457,9 @@ reader = BurleighReader
 
 [Canon DNG]
 extensions = .cr2, .crw
-developer = `Canon <http://global.canon/en/index.html>`_
+developer = `Canon <https://global.canon/en/index.html>`_
 bsd = no
-software = `IrfanView <http://www.irfanview.com/>`_
+software = `IrfanView <https://www.irfanview.com/>`_
 weHave = * a few example datasets
 weWant = * an official specification document
 pixelsRating = Good
@@ -555,7 +555,7 @@ notes = - The Deltavision format is based on the Medical Research Council (MRC) 
 
 [DICOM]
 extensions = .dcm, .dicom
-developer = `National Electrical Manufacturers Association <http://www.nema.org/>`_
+developer = `National Electrical Manufacturers Association <https://www.nema.org/>`_
 bsd = yes
 software = `OsiriX Medical Imaging Software <http://www.osirix-viewer.com/>`_ \n
 `ezDICOM <http://www.sph.sc.edu/comd/rorden/ezdicom.html>`_ \n
@@ -580,7 +580,7 @@ reasons, please send us the exact error message and be aware that it may take \n
 several attempts to fix the problem blind. \n
 \n
 .. seealso:: \n
-  `DICOM homepage <http://www.dicomstandard.org/>`_
+  `DICOM homepage <https://www.dicomstandard.org/>`_
 
 [ECAT7]
 extensions = .v
@@ -716,7 +716,7 @@ Note that the Gatan Reader does not currently support stacks.
 [GIF (Graphics Interchange Format)]
 pagename = gif
 extensions = .gif
-owner = `Unisys <http://www.unisys.com/>`_
+owner = `Unisys <https://www.unisys.com/>`_
 developer = `CompuServe <http://www.compuserve.com/>`_
 bsd = yes
 software = `Animated GIF Reader plugin for ImageJ <https://imagej.nih.gov/ij/plugins/agr.html>`_ \n
@@ -733,7 +733,7 @@ reader = GIFReader
 
 [Hamamatsu Aquacosmos NAF]
 extensions = .naf
-developer = `Hamamatsu <http://www.hamamatsu.com>`_
+developer = `Hamamatsu <https://www.hamamatsu.com/>`_
 bsd = no
 weHave = * a few NAF files
 weWant = * a specification document \n
@@ -748,7 +748,7 @@ mif = true
 
 [Hamamatsu HIS]
 extensions = .his
-owner = `Hamamatsu <http://www.hamamatsu.com>`_
+owner = `Hamamatsu <https://www.hamamatsu.com/>`_
 bsd = no
 weHave = * Pascal code that can read HIS files (from ImageSXM) \n
 * several HIS files
@@ -764,9 +764,9 @@ mif = true
 
 [Hamamatsu ndpi]
 extensions = .ndpi, .ndpis
-developer = `Hamamatsu <http://www.hamamatsu.com>`_
+developer = `Hamamatsu <https://www.hamamatsu.com/>`_
 bsd = no
-software = `NDP.view2 <http://www.hamamatsu.com/eu/en/community/nanozoomer/product/search/U12388-01/index.html>`_ \n
+software = `NDP.view2 <https://www.hamamatsu.com/eu/en/community/nanozoomer/product/search/U12388-01/index.html>`_ \n
 `OpenSlide <https://openslide.org>`_
 weHave = * many example datasets \n
 * `public sample images <http://downloads.openmicroscopy.org/images/Hamamatsu-NDPI/>`__
@@ -800,7 +800,7 @@ mif = true
 
 [Hitachi S-4800]
 extensions = .txt, .tif, .bmp, .jpg
-developer = `Hitachi <http://www.hitachi-hta.com/sites/default/files/technotes/Hitachi_4800_STEM.pdf>`_
+developer = `Hitachi <https://www.hitachi-hta.com/sites/default/files/technotes/Hitachi_4800_STEM.pdf>`_
 bsd = no
 weHave = * several Hitachi S-4800 datasets
 pixelsRating = Very good
@@ -832,7 +832,7 @@ bsd = yes
 versions = 1.0, 2.0
 software = `Libics (ICS reference library) <http://libics.sourceforge.net/>`_ \n
 `ICS Opener plugin for ImageJ <https://valelab4.ucsf.edu/~nstuurman/IJplugins/Ics_Opener.html>`_ \n
-`IrfanView <http://www.irfanview.com/>`_
+`IrfanView <https://www.irfanview.com/>`_
 weHave = * numerous ICS datasets
 pixelsRating = Outstanding
 metadataRating = Outstanding
@@ -1199,7 +1199,7 @@ mif = true
 [Khoros VIFF (Visualization Image File Format) Bitmap]
 pagename = khoros-viff-bitmap
 extensions = .xv
-owner = `AccuSoft <http://www.accusoft.com/company/>`_
+owner = `AccuSoft <https://www.accusoft.com/company/>`_
 developer = Khoral
 bsd = no
 samples = `VIFF Images <http://netghost.narod.ru/gff/sample/images/viff/index.htm>`_
@@ -1427,7 +1427,7 @@ notes = Commercial applications that support STK include: \n
 
 [MIAS (Maia Scientific)]
 extensions = .tif
-developer = `Maia Scientific <http://www.selectscience.net/supplier/maia-scientific/?compID=6088>`_
+developer = `Maia Scientific <https://www.selectscience.net/supplier/maia-scientific/?compID=6088>`_
 bsd = no
 weHave = * several MIAS datasets
 pixelsRating = Very good
@@ -1756,7 +1756,7 @@ mif = true
 
 [Olympus SIS TIFF]
 extensions = .tiff
-developer = `Olympus <http://www.olympus-sis.com/>`_
+developer = `Olympus <https://www.olympus-sis.com/>`_
 bsd = no
 weHave = * a few example SIS TIFF files
 pixelsRating = Good

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -139,7 +139,7 @@ reader = AnalyzeReader
 [Andor Bio-Imaging Division (ABD) TIFF]
 pagename = abd-tiff
 extensions = .tif
-owner = `Andor Technology <http://www.andor.com/>`_
+owner = `Andor Technology <https://andor.oxinst.com/>`_
 developer = Andor Bioimaging Department
 bsd = no
 weHave = * an ABD-TIFF specification document (from 2005 November, in PDF) \n
@@ -157,7 +157,7 @@ Fluoview TIFF format.
 
 [Andor SIF]
 extensions = .sif
-owner = `Andor Technology <http://www.andor.com/>`_
+owner = `Andor Technology <https://andor.oxinst.com/>`_
 developer = Andor Bioimaging Department
 bsd = no
 weHave = * a small number of Andor SIF datasets
@@ -1839,7 +1839,7 @@ Commercial applications that support OME-XML include: \n
 
 [Oxford Instruments]
 extensions = .top
-owner = `Oxford Instruments <https://www.oxford-instruments.com/>`_
+owner = `Oxford Instruments <https://www.oxinst.com/>`_
 bsd = no
 weHave = * Pascal code that can read Oxford Instruments files (from ImageSXM) \n
 * a few Oxford Instruments files
@@ -2472,7 +2472,7 @@ notes = .mvd2 files are `Metakit database files <https://equi4.com/metakit/>`_.
 
 [WA-TOP]
 extensions = .wat
-owner = `Oxford Instruments <https://www.oxford-instruments.com/>`_
+owner = `Oxford Instruments <https://www.oxinst.com/>`_
 developer = WA Technology
 bsd = no
 weHave = * Pascal code that can read WA-TOP files (from ImageSXM) \n

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -207,7 +207,7 @@ notes = .. seealso:: \n
 extensions = .svs
 owner = `Aperio <http://www.aperio.com/>`_
 bsd = no
-software = `OpenSlide <http://openslide.org>`_
+software = `OpenSlide <https://openslide.org>`_
 versions = 8.0, 8.2, 9.0
 weHave = * many SVS datasets\n
 * `public sample images <http://downloads.openmicroscopy.org/images/SVS/>`__\n
@@ -767,7 +767,7 @@ extensions = .ndpi, .ndpis
 developer = `Hamamatsu <http://www.hamamatsu.com>`_
 bsd = no
 software = `NDP.view2 <http://www.hamamatsu.com/eu/en/community/nanozoomer/product/search/U12388-01/index.html>`_ \n
-`OpenSlide <http://openslide.org>`_
+`OpenSlide <https://openslide.org>`_
 weHave = * many example datasets \n
 * `public sample images <http://downloads.openmicroscopy.org/images/Hamamatsu-NDPI/>`__
 weWant = * an official specification document
@@ -784,10 +784,10 @@ pyramid = yes
 extensions = .vms
 developer = `Hamamatsu <http://www.hamamatsu.com>`_
 bsd = no
-software = `OpenSlide <http://openslide.org>`_
+software = `OpenSlide <https://openslide.org>`_
 weHave = * a few example datasets \n
 * `public sample images <http://downloads.openmicroscopy.org/images/Hamamatsu-VMS/>`__ \n
-* `developer documentation from the OpenSlide project <http://openslide.org/Hamamatsu%20format/>`_
+* `developer documentation from the OpenSlide project <https://openslide.org/Hamamatsu%20format/>`_
 weWant = * an official specification document \n
 * more example datasets
 pixelsRating = Good
@@ -1322,7 +1322,7 @@ Commercial applications that support LEI include: \n
 extensions = .scn
 developer = `Leica Microsystems <https://www.leica-microsystems.com/>`_
 bsd = no
-software = `OpenSlide <http://openslide.org>`_
+software = `OpenSlide <https://openslide.org>`_
 versions = 2012-03-10
 weHave = * a few sample datasets
 weWant = * an official specification document \n
@@ -2345,7 +2345,7 @@ extensions = .tif, .sld, .jpg
 bsd = no
 samples = `OpenSlide <http://openslide.cs.cmu.edu/download/openslide-testdata/Trestle/>`_
 weHave = * a few example datasets \n
-* `developer documentation from the OpenSlide project <http://openslide.org/Trestle%20format/>`_
+* `developer documentation from the OpenSlide project <https://openslide.org/Trestle%20format/>`_
 pixelsRating = Good
 metadataRating = Good
 opennessRating = Good


### PR DESCRIPTION
See https://web-proxy.openmicroscopy.org/west-ci/job/BIOFORMATS-docs/134/. One of the URLs broke the linkcheck with `Exceeded 30 redirects.`

This PR reviews some of the URLS marked as `Permanently redirected` by the linkchecked, primarily in the components and format pages.

- use GitHub `sourcedir` extlink rather than `source` for components
- fix the organization of the https://github.com/ome/bio-formats-examples repository
- fix most of the permanently redirected URLs in the Format pages, switching to HTTPS whenever possible

