### PR TITLE
Add infrastructure for deploying artifacts on tags via Travis

### DIFF
--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -1,0 +1,13 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+      <server>
+        <id>ome.staging</id>
+        <username>${env.CI_DEPLOY_USER}</username>
+        <password>${env.CI_DEPLOY_PASS}</password>
+      </server>
+  </servers>
+</settings>
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,11 @@ before_install:
 
 script:
   - mvn install -DskipSphinxTests=true
+
+deploy:
+  provider: script
+  script: "cp .travis.settings.xml $HOME/.m2/settings.xml && mvn -DskipTests=true deploy"
+  skip_cleanup: true
+  on:
+    tags: true
+    jdk: oraclejdk8


### PR DESCRIPTION
- https://docs.travis-ci.com/user/deployment/ to release the documentation artifact to the OME artifactory.
- consume secret environment variables that should be set up at the Travis level
- only deploy for the JDK8 build

See also https://github.com/ome/bio-formats-examples/pull/36