### PR TITLE
Replace www.farsight-toolkit.org by farsight-toolkit.ee.uh.edu

### DIFF
--- a/sphinx/users/farsight/index.rst
+++ b/sphinx/users/farsight/index.rst
@@ -1,7 +1,7 @@
 FARSIGHT
 ========
 
-`FARSIGHT <http://www.farsight-toolkit.org/wiki/Main_Page>`_ is a collection of
+`FARSIGHT <http://farsight-toolkit.ee.uh.edu/wiki/Main_Page>`_ is a collection of
 modules for image analysis created by LOCI's collaborators at the
 `University of Houston <http://www.uh.edu/>`_. These
 open source modules are built on the :doc:`/users/itk/index` library
@@ -9,11 +9,11 @@ and thus can take advantage of ITK's support for Bio-Formats to process
 otherwise unsupported image formats.
 
 The principal FARSIGHT module that benefits from Bio-Formats is the
-`Nucleus Editor <http://www.farsight-toolkit.org/wiki/NucleusEditor>`_,
+`Nucleus Editor <http://farsight-toolkit.ee.uh.edu/wiki/NucleusEditor>`_,
 though in principle any FARSIGHT-based code that reads image formats via
 the standard ITK mechanism will be able to leverage Bio-Formats.
 
 .. seealso::
-    `FARSIGHT Downloads page <http://www.farsight-toolkit.org/wiki/Special:FarsightDownloads>`_
+    `FARSIGHT Downloads page <http://farsight-toolkit.ee.uh.edu/wiki/Special:FarsightDownloads>`_
 
-    `FARSIGHT HowToBuild tutorial <http://www.farsight-toolkit.org/wiki/FARSIGHT_HowToBuild>`_
+    `FARSIGHT HowToBuild tutorial <http://farsight-toolkit.ee.uh.edu/wiki/FARSIGHT_HowToBuild>`_

--- a/sphinx/users/vaa3d/index.rst
+++ b/sphinx/users/vaa3d/index.rst
@@ -8,5 +8,5 @@ handy, fast, and versatile 3D/4D/5D Image Visualization & Analysis
 System for Bioimages & Surface Objects.
 
 Vaa3D can use Bio-Formats via the `Bio-Formats C++
-bindings <http://www.farsight-toolkit.org/wiki/FARSIGHT_Tutorials/Building_Software/Bio-Formats/Building_C%2B%2B_Bindings>`_
+bindings <http://farsight-toolkit.ee.uh.edu/wiki/FARSIGHT_Tutorials/Building_Software/Bio-Formats/Building_C%2B%2B_Bindings>`_
 to read images.


### PR DESCRIPTION
The org domain seems to have gone away. This updates the documentation
to use another domain which serves the same content