### PR TITLE
Add first version of history changes for 6.0.0-m2

### DIFF
--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -19,11 +19,11 @@ Bio-Formats API changes:
   - deprecated ``getCoreMetadataList``, ``seriesToCoreIndex``, 
     ``coreIndexToSeries``, ``getCoreIndex`` and ``setCoreIndex`` in
     ``IFormatWriter``
-* Added a new ``IPyramidHandler`` interface with the resolution getters methods
+* Added a new ``IPyramidHandler`` interface with the resolution getter methods
 * Subresolution writing changes:
 
   - ``IFormatWriter`` now extends``IPyramidHandler`` (breaking)
-  - added ``setResolutions`` and ``getResolutions`` methors to
+  - added ``setResolutions`` and ``getResolutions`` methods to
     ``IFormatWriter`` (breaking)
   - added examples of using the sub-resolution writing API
 
@@ -62,7 +62,7 @@ File format fixes and improvements:
 * Zeiss TIFF
    - added support for AVI files acquired with Keyence software
 * Updated all pyramidal format readers to consume ``SubResolutionReader``
-* Updated all readers to consumer ``MetadataTools`` getter to retrieve enumerations
+* Updated all readers to consume ``MetadataTools`` getter to retrieve enumerations
 
 Plugins and tools improvements:
 
@@ -73,7 +73,8 @@ Plugins and tools improvements:
 Automated test changes:
 
 * Add ``testng.allow-missing`` property allowing to skip unconfigured filesets
-* Add ``testUnflattenedSaneOMEXML`` to compare series count to OME-XML images    count when resolution flattening is disabled
+* Add ``testUnflattenedSaneOMEXML`` to compare series count to OME-XML images
+  count when resolution flattening is disabled
 * Add ``test-equivalent`` target to compare pixel data between two files
 * Added support for storing resolution index and resolution count in the
   configuration files used for automated testing

--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -68,7 +68,7 @@ Plugins and tools improvements:
 
 * updated the updater message in the Fiji plugin (thanks to Jan Eglinger)
 * added ``-no-flat`` option to the command-line tools to convert files with
-  subresolutions
+  sub-resolutions
 
 Automated test changes:
 

--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -20,7 +20,7 @@ Bio-Formats API changes:
     ``coreIndexToSeries``, ``getCoreIndex`` and ``setCoreIndex`` in
     ``IFormatWriter``
 * Added a new ``IPyramidHandler`` interface with the resolution getter methods
-* Subresolution writing changes:
+* Sub-resolution writing changes:
 
   - ``IFormatWriter`` now extends``IPyramidHandler`` (breaking)
   - added ``setResolutions`` and ``getResolutions`` methods to
@@ -31,7 +31,7 @@ Bio-Formats API changes:
 
   - added getter methods to ``MetadataTools`` for retrieving OME
     enumerations by value
-  - deprecated OME enumerations getter methods in ``FormatReader``
+  - deprecated OME enumeration getter methods in ``FormatReader``
 
 New file formats:
 

--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -4,6 +4,10 @@ Version history
 6.0.0-m2 (2018 October)
 -----------------------
 
+This is a developer milestone release intended as a preview before the
+full public release of Bio-Formats 6.0.0. None of the API changes should be
+considered as final at this stage.
+
 Bio-Formats API changes:
 
 * Sub-resolution reading:

--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -1,8 +1,24 @@
 Version history
 ===============
 
-6.0.0-m1 (2018 September)
+6.0.0-m2 (2018 September)
 -------------------------
+
+Bio-Formats API changes:
+
+* Sub-resolution reading
+  - added ``MetadataList`` and ``CoreMetadataList`` classes
+  - added a new ``SubResolutionFormatReader`` abstract class for handling
+  - updated all pyramid format readers to use ``SubResolutionFormatReader``
+* Added a new ``IPyramidHandler`` interface with the resolution getters methods
+* Subresolution writing changes
+  - ``IFormatWriter`` now extends``IPyramidHandler`` (breaking)
+  - added ``setResolutions`` and ``getResolutions`` to ``IFormatWriter`` (breaking)
+* Added getter methods to ``MetadataTools`` to retrieve enumeration by value
+OME-TIFF improvements:
+
+* Added ``loci.formats.out.PyramidOMETiffWriter``
+* Added loci.formats.out.PyramidOMETiffWriter
 
 New file formats:
 
@@ -21,6 +37,9 @@ File format fixes and improvements:
 * Nikon ND2
    - prevents integer overflow when reading chunkmaps from files larger than
      2GB
+* OME-TIFF
+   - added support for reading OME-TIFF with pyramidal resolutions
+   - added support for writing OME-TIFF with pyramidal resolutions
 * TIFF
    - split IFDs into separate series if the dimensions or pixel type mismatch
    - restrict use case for legacy TIFF JAI reader
@@ -30,6 +49,15 @@ File format fixes and improvements:
 Plugins and tools improvements:
 
 * update the updater message in the Fiji plugin (thanks to Jan Eglinger)
+* added ``-no-flat`` option to the command-line tools to convert files with
+  subresolutions
+
+Automated test changes:
+
+* Add ``testng.allow-missing`` property allowing to skip unconfigured filesets
+* Add ``testUnflattenedSaneOMEXML`` to compare series count to OME-XML images    count when resolution flattening is disabled
+* Add ``test-equivalent`` target to compare pixel data between two files
+* Improve the configuratoin
 
 Documentation improvements:
 

--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -22,7 +22,7 @@ Bio-Formats API changes:
 * Added a new ``IPyramidHandler`` interface with the resolution getter methods
 * Sub-resolution writing changes:
 
-  - ``IFormatWriter`` now extends``IPyramidHandler`` (breaking)
+  - ``IFormatWriter`` now extends ``IPyramidHandler`` (breaking)
   - added ``setResolutions`` and ``getResolutions`` methods to
     ``IFormatWriter`` (breaking)
   - added examples of using the sub-resolution writing API

--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -1,24 +1,33 @@
 Version history
 ===============
 
-6.0.0-m2 (2018 September)
--------------------------
+6.0.0-m2 (2018 October)
+-----------------------
 
 Bio-Formats API changes:
 
-* Sub-resolution reading
+* Sub-resolution reading:
+
   - added ``MetadataList`` and ``CoreMetadataList`` classes
   - added a new ``SubResolutionFormatReader`` abstract class for handling
+    pyramidal format readers
   - updated all pyramid format readers to use ``SubResolutionFormatReader``
+  - deprecated ``getCoreMetadataList``, ``seriesToCoreIndex``, 
+    ``coreIndexToSeries``, ``getCoreIndex`` and ``setCoreIndex`` in
+    ``IFormatWriter``
 * Added a new ``IPyramidHandler`` interface with the resolution getters methods
-* Subresolution writing changes
-  - ``IFormatWriter`` now extends``IPyramidHandler`` (breaking)
-  - added ``setResolutions`` and ``getResolutions`` to ``IFormatWriter`` (breaking)
-* Added getter methods to ``MetadataTools`` to retrieve enumeration by value
-OME-TIFF improvements:
+* Subresolution writing changes:
 
-* Added ``loci.formats.out.PyramidOMETiffWriter``
-* Added loci.formats.out.PyramidOMETiffWriter
+  - ``IFormatWriter`` now extends``IPyramidHandler`` (breaking)
+  - added ``setResolutions`` and ``getResolutions`` methors to
+    ``IFormatWriter`` (breaking)
+  - added examples of using the sub-resolution writing API
+
+* Metadata handling:
+
+  - added getter methods to ``MetadataTools`` for retrieving OME
+    enumerations by value
+  - deprecated OME enumerations getter methods in ``FormatReader``
 
 New file formats:
 
@@ -27,6 +36,8 @@ New file formats:
 
 File format fixes and improvements:
 
+* Fake
+   - added support for multi-resolution test images
 * DICOM
    - improve file grouping and file-to-series mapping for multi-file datasets
 * Image Pro
@@ -38,13 +49,16 @@ File format fixes and improvements:
    - prevents integer overflow when reading chunkmaps from files larger than
      2GB
 * OME-TIFF
-   - added support for reading OME-TIFF with pyramidal resolutions
+   - added support for reading OME-TIFF with pyramidal resolutions stored as
+     SubIFDs
    - added support for writing OME-TIFF with pyramidal resolutions
 * TIFF
    - split IFDs into separate series if the dimensions or pixel type mismatch
    - restrict use case for legacy TIFF JAI reader
 * Zeiss TIFF
    - added support for AVI files acquired with Keyence software
+* Updated all pyramidal format readers to consume ``SubResolutionReader``
+* Updated all readers to consumer ``MetadataTools`` getter to retrieve enumerations
 
 Plugins and tools improvements:
 
@@ -57,7 +71,8 @@ Automated test changes:
 * Add ``testng.allow-missing`` property allowing to skip unconfigured filesets
 * Add ``testUnflattenedSaneOMEXML`` to compare series count to OME-XML images    count when resolution flattening is disabled
 * Add ``test-equivalent`` target to compare pixel data between two files
-* Improve the configuratoin
+* Added support for storing resolution index and resolution count in the
+  configuration files used for automated testing
 
 Documentation improvements:
 

--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -43,14 +43,14 @@ File format fixes and improvements:
 * Fake
    - added support for multi-resolution test images
 * DICOM
-   - improve file grouping and file-to-series mapping for multi-file datasets
+   - improved file grouping and file-to-series mapping for multi-file datasets
 * Image Pro
-   - add support for Image Pro Plus .ips set
+   - added support for Image Pro Plus .ips set
 * Metamorph
-   - add support for multi-dimensional .scan dataset created from
+   - added support for multi-dimensional .scan dataset created from
      Scan Slide (thanks to Jeremy Muhlich)
 * Nikon ND2
-   - prevents integer overflow when reading chunkmaps from files larger than
+   - prevented integer overflow when reading chunkmaps from files larger than
      2GB
 * OME-TIFF
    - added support for reading OME-TIFF with pyramidal resolutions stored as
@@ -58,31 +58,30 @@ File format fixes and improvements:
    - added support for writing OME-TIFF with pyramidal resolutions
 * TIFF
    - split IFDs into separate series if the dimensions or pixel type mismatch
-   - restrict use case for legacy TIFF JAI reader
+   - restricted use case for legacy TIFF JAI reader
 * Zeiss TIFF
    - added support for AVI files acquired with Keyence software
-* Updated all pyramidal format readers to consume ``SubResolutionReader``
-* Updated all readers to consume ``MetadataTools`` getter to retrieve enumerations
+* updated all pyramidal format readers to consume ``SubResolutionReader``
+* updated all readers to consume ``MetadataTools`` getter to retrieve enumerations
 
 Plugins and tools improvements:
 
-* update the updater message in the Fiji plugin (thanks to Jan Eglinger)
+* updated the updater message in the Fiji plugin (thanks to Jan Eglinger)
 * added ``-no-flat`` option to the command-line tools to convert files with
   subresolutions
 
 Automated test changes:
 
-* Add ``testng.allow-missing`` property allowing to skip unconfigured filesets
-* Add ``testUnflattenedSaneOMEXML`` to compare series count to OME-XML images
+* added ``testng.allow-missing`` property allowing to skip unconfigured filesets
+* added ``testUnflattenedSaneOMEXML`` to compare series count to OME-XML images
   count when resolution flattening is disabled
-* Add ``test-equivalent`` target to compare pixel data between two files
-* Added support for storing resolution index and resolution count in the
+* added ``test-equivalent`` target to compare pixel data between two files
+* added support for storing resolution index and resolution count in the
   configuration files used for automated testing
 
 Documentation improvements:
 
-* extend ``IFormatReader`` Javadocs to reflect the reader guide
-
+* extended ``IFormatReader`` Javadocs to reflect the reader guide
 
 5.9.2 (2018 September 03)
 -------------------------


### PR DESCRIPTION
Includes the changes associated with the OME-TIFF pyramid reading and writing

I tried to summarize all the changes included in https://github.com/openmicroscopy/bioformats/pull/3223 and the relevant PRs (listed in the description).