### PR TITLE
Exclude merckmillipore from the linkcheck

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -389,4 +389,5 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://cbia.fi.muni.cz.*',
     r'https://www.fei.com/.*',
     'https://animatedpngs.com/', # SSL certificate error
+    'https://www.merckmillipore.com', # Read timeout
 ]


### PR DESCRIPTION
This has been flaky as shown by `curl -Il https://www.merckmillipore.com` which times out

Expected result: https://web-proxy.openmicroscopy.org/east-ci/job/BIOFORMATS-merge-docs/ should turn green