### PR TITLE
2018-11: fixes for doc links

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -400,6 +400,8 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     'https://nifti.nimh.nih.gov/nifti-1/',
     r'https://cbia.fi.muni.cz.*',
     r'https://www.fei.com/.*',
+    r'https?://www.ionpath.com/.*',
+    'http://cellularimaging.perkinelmer.com/downloads/',
     'https://animatedpngs.com/', # SSL certificate error
     'https://www.merckmillipore.com', # Read timeout
 ]


### PR DESCRIPTION
 * Perkin Elmer: even internal links, e.g. from
   http://www.perkinelmer.com/lab-products-and-services/resources/software-downloads.html
   are 404
 * Ion Path: unsure why but this is failing regularly