### PR TITLE
Users documentation: create a new level of hierarchy for the command-line tools

### DIFF
--- a/sphinx/users/comlinetools/index.rst
+++ b/sphinx/users/comlinetools/index.rst
@@ -1,8 +1,22 @@
-Command line tools introduction
-===============================
+Command line tools
+==================
 
-There are several scripts for using Bio-Formats on the command
-line.
+There are several scripts for using Bio-Formats on the command line.
+
+.. toctree::
+    :maxdepth: 1
+    :titlesonly:
+    :hidden:
+
+    display
+    conversion
+    xml-validation
+    edit
+    domainlist
+    formatlist
+    ijview
+    xmlindent
+    mkfake
 
 Installation
 ------------

--- a/sphinx/users/index.rst
+++ b/sphinx/users/index.rst
@@ -31,19 +31,10 @@ The Bio-Formats Command line tools (bftools.zip) provide a complete package
 for carrying out a variety of tasks:
 
 .. toctree::
-    :maxdepth: 1
     :titlesonly:
+    :includehidden:
 
     comlinetools/index
-    comlinetools/display
-    comlinetools/conversion
-    comlinetools/xml-validation
-    comlinetools/edit
-    comlinetools/domainlist
-    comlinetools/formatlist
-    comlinetools/ijview
-    comlinetools/xmlindent
-    comlinetools/mkfake
 
 .. seealso::
    :doc:`/formats/options`


### PR DESCRIPTION
Opening  for discussion following the thread started in #58 

This PR proposes to refactor the Sphinx toctree hierarchy for the `users` section of the technical documentation to create an extra level for the command-line tools.

This already matches the organization of the rST source files under a single `comlinetools/` folder. The main advantage of this structure so is that it creates an extra layer of hierarchy in the top-level navigation bar allowing to go back to the Command line tools index page rather than back to the Users index page.