### PR TITLE
Use HTTPS for Nikon external URLS

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -404,4 +404,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     'http://cellularimaging.perkinelmer.com/downloads/',
     'https://animatedpngs.com/', # SSL certificate error
     'https://www.merckmillipore.com', # Read timeout
+    r'https://www.nis-elements.com/.*', # Invalid SSL certificate
+    r'https://www.nikoninstruments.com/.*', # Invalid SSL certificate
 ]

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -1390,7 +1390,7 @@ notes = Bio-Formats only supports uncompressed LIM files. \n
 \n
 Commercial applications that support LIM include: \n
 \n
-* `NIS Elements <http://www.nis-elements.com/>`_
+* `NIS Elements <https://www.nis-elements.com/>`_
 
 [MetaMorph 7.5 TIFF]
 extensions = .tiff
@@ -1612,7 +1612,7 @@ reader = NikonTiffReader
 extensions = .nd2
 developer = `Nikon USA <https://www.nikonusa.com/en/index.page>`_
 bsd = no
-software = `NIS-Elements Viewer from Nikon <http://www.nikoninstruments.com/Products/Software/NIS-Elements-Advanced-Research/NIS-Elements-Viewer>`_
+software = `NIS-Elements Viewer from Nikon <https://www.nikoninstruments.com/Products/Software/NIS-Elements-Advanced-Research/NIS-Elements-Viewer>`_
 weHave = * many ND2 datasets\n
 * `public sample images <https://downloads.openmicroscopy.org/images/ND2/>`__
 weWant = * an official specification document


### PR DESCRIPTION
This should address https://web-proxy.openmicroscopy.org/east-ci/job/BIOFORMATS-merge-docs/jdk=JDK8,label=testintegration/250/