### PR TITLE
Add current Adobe specification link

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -2299,7 +2299,8 @@ owner = `Adobe <https://www.adobe.com>`_
 developer = Aldus and Microsoft
 bsd = yes
 samples = `Big TIFF <https://www.awaresystems.be/imaging/tiff/bigtiff.html#samples>`_
-weHave = * a `TIFF specification document <https://www.awaresystems.be/imaging/tiff.html>`_ \n
+weHave = * `TIFF specification documents from Adobe <https://www.adobe.io/open/standards/TIFF.html>`_ \n
+* a `TIFF specification document <https://www.awaresystems.be/imaging/tiff.html>`_ \n
 * `public sample images <https://downloads.openmicroscopy.org/images/TIFF/>`__\n
 * many TIFF datasets \n
 * a few BigTIFF datasets


### PR DESCRIPTION
Noticed by @sbesson, see https://openmicroscopy.slack.com/archives/C0K5EED3R/p1543418497947800