### PR TITLE
for Gatan fix Datasqueeze link since going freeware

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -724,7 +724,7 @@ opennessRating = Fair
 presenceRating = Fair
 utilityRating = Fair
 reader = GatanReader
-notes = Commercial applications that support .dm3 files include `Datasqueeze <http://www.datasqueezesoftware.com/>`_. \n
+notes = Applications that support .dm3 files include `Datasqueeze <https://www.sas.upenn.edu/~heiney/html-physics/datasqueeze/>`_. \n
 \n
 Note that the Gatan Reader does not currently support stacks.
 


### PR DESCRIPTION
Datasqueeze seems to have become less commercial. See [BIOFORMATS-merge-docs](https://web-proxy.openmicroscopy.org/east-ci/job/BIOFORMATS-merge-docs/).