### PR TITLE
Move sample-data to scif.io

### DIFF
--- a/sphinx/users/imagej/load-images.rst
+++ b/sphinx/users/imagej/load-images.rst
@@ -77,9 +77,9 @@ One of the most important features of Bio-Formats is to combine multiple
 files from a data set into one coherent, multi-dimensional image.
 
 To demonstrate how to use the **Group files with similar
-names** feature, you can use the `dub <http://loci.wisc.edu/sample-data/dub>`_
+names** feature, you can use the `dub <https://scif.io/images/>`_
 data set available under LOCI’s `Sample
-Data <http://loci.wisc.edu/software/sample-data>`_ page. You will
+Data <https://scif.io/images/>`_ page. You will
 notice that it is a large dataset: each of the 85 files shows the
 specimen at 33 optical sections along the z-plane at a specific time.
 


### PR DESCRIPTION
http://loci.wisc.edu/software/sample-data now redirects to https://samples.scif.io/images/ which 404s (Now: https://scif.io/images/)

Opening this to get the build green.