### PR TITLE
Add -noflat option to the showinf and bfconvert users pages

### DIFF
--- a/sphinx/developers/wsi.rst
+++ b/sphinx/developers/wsi.rst
@@ -61,7 +61,7 @@ shows a simple example of how to do this.
 
 The :source:`bfconvert command line tool <components/bio-formats-tools/src/loci/formats/tools/ImageConverter.java>` will also
 automatically write pyramids if the input file has at least one pyramid, the output format is OME-TIFF,
-and the ``-noflat`` option is specified.
+and the :option:`bfconvert -noflat` option is specified.
 
 .. _omero-pyramid:
 

--- a/sphinx/users/comlinetools/conversion.rst
+++ b/sphinx/users/comlinetools/conversion.rst
@@ -32,9 +32,11 @@ The output file format is determined by the extension of the output file, e.g.
 .. option:: -noflat
 
     Do not flatten the series i.e. use the sub-resolution API for images
-    with pyramidal levels::
+    with pyramidal levels. This option is mandatory to generate an output
+    image with pyramidal levels. As of Bio-Formats 6.0.0, only the OME-TIFF
+    writer properly supports this option::
 
-      bfconvert -noflat /path/to/input output-first-series.tiff
+      bfconvert -noflat /path/to/input output-first-series.ome.tiff
 
     .. versionadded:: 6.0.0
 

--- a/sphinx/users/comlinetools/conversion.rst
+++ b/sphinx/users/comlinetools/conversion.rst
@@ -31,10 +31,10 @@ The output file format is determined by the extension of the output file, e.g.
 
 .. option:: -noflat
 
-    Do not flatten the series i.e. use the sub-resolution API for images
-    with pyramidal levels. This option is mandatory to generate an output
-    image with pyramidal levels. As of Bio-Formats 6.0.0, only the OME-TIFF
-    writer properly supports this option::
+    Do not flatten resolutions into individual series. This option is mandatory
+    to read images with pyramidal levels using the sub-resolution API and
+    generate an output image with sub-resolutions. As of Bio-Formats 6.0.0,
+    only the OME-TIFF output format properly supports this option::
 
       bfconvert -noflat /path/to/input output-first-series.ome.tiff
 

--- a/sphinx/users/comlinetools/conversion.rst
+++ b/sphinx/users/comlinetools/conversion.rst
@@ -180,3 +180,19 @@ name pattern, then the other must be included too.  The only exception is if
       bfconvert /path/to/input output_xy%sz%zc%ct%t.ome.tif -padded
 
     .. versionadded:: 5.2.2
+
+.. option:: -pyramid-resolutions RESOLUTIONS
+.. option:: -pyramid-scale SCALE
+
+    When using :option:`-noflat` by default, each series of the converted file
+    will contain the same number of resolutions as in the input file. The
+    :option:`-pyramid-resolutions` option allows to set the number of
+    expected resolutions in the output file for each series. If the target
+    number of resolutions is greater than the actual number of sub-resolutions
+    present in the input file, additional pyramidal levels will be calculated
+    using the downsampling factor specified by the :option:`-pyramid-scale`
+    option::
+
+      bfconvert -noflat -pyramid-resolutions 4 -pyramid-scale 2 /path/to/input out.ome.tiff
+
+    .. versionadded:: 6.0.0

--- a/sphinx/users/comlinetools/conversion.rst
+++ b/sphinx/users/comlinetools/conversion.rst
@@ -29,6 +29,15 @@ The output file format is determined by the extension of the output file, e.g.
 
     .. versionadded:: 5.4.0
 
+.. option:: -noflat
+
+    Do not flatten the series i.e. use the sub-resolution API for images
+    with pyramidal levels::
+
+      bfconvert -noflat /path/to/input output-first-series.tiff
+
+    .. versionadded:: 6.0.0
+
 .. option:: -series SERIES
 
     All images in the input file are converted by default.  To convert only

--- a/sphinx/users/comlinetools/display.rst
+++ b/sphinx/users/comlinetools/display.rst
@@ -21,8 +21,7 @@ dimensions, and other basic metadata will be printed to the console.
 
 .. option:: -noflat
 
-    Do not flatten the series i.e. use the sub-resolution API for images
-    with pyramidal levels::
+    Do not flatten resolutions into individual series::
 
       showinf -noflat /path/to/file
 

--- a/sphinx/users/comlinetools/display.rst
+++ b/sphinx/users/comlinetools/display.rst
@@ -19,6 +19,13 @@ All of the images in the first 'series' (or 5 dimensional stack) will be
 opened and displayed in a simple image viewer.  The number of series, image
 dimensions, and other basic metadata will be printed to the console.
 
+.. option:: -noflat
+
+    Do not flatten the series i.e. use the sub-resolution API for images
+    with pyramidal levels::
+
+      showinf -noflat /path/to/file
+
 .. option:: -series SERIES
 
     Displays a different series, for example the second one:


### PR DESCRIPTION
Noticed while reviewing #78. We currently do not mention the `-noflat` option either in the `showinf` page or in the `bfconvert` page (new 6.0.0 feature).

Not a blocker for 6.0.0 but it should be straightforward addition.