### PR TITLE
Review minimal MATLAB version

### DIFF
--- a/sphinx/developers/matlab-dev.rst
+++ b/sphinx/developers/matlab-dev.rst
@@ -5,7 +5,7 @@ Using Bio-Formats in MATLAB
 
 This section assumes that you have installed the MATLAB toolbox as instructed
 in the :doc:`MATLAB user information page </users/matlab/index>`. Note the
-minimum supported MATLAB version is R2007b (7.5).
+minimum recommended MATLAB version is R2017b.
 
 As described in `Using Java Libraries <http://mathworks.com/help/matlab/matlab_external/product-overview.html>`_,
 every installation of MATLAB includes a |JVM| allowing use of the Java API and

--- a/sphinx/users/matlab/index.rst
+++ b/sphinx/users/matlab/index.rst
@@ -6,9 +6,19 @@ language and interactive environment that facilitates rapid development
 of algorithms for performing computationally intensive tasks.
 
 Calling Bio-Formats from MATLAB is fairly straightforward, since MATLAB
-has built-in interoperability with Java. We have created a :sourcedir:`set
-of scripts <components/formats-gpl/matlab>` for reading image files. Note
-the minimum supported MATLAB version is R2007b (7.5).
+has built-in interoperability with Java. We have created a
+:sourcedir:`toolbox <components/formats-gpl/matlab>` for reading and writing
+image files. Note the minimum recommended MATLAB version is R2017b.
+
+.. note::
+
+   It is possible to run Bio-Formats 6 on earlier MATLAB versions using a
+   the JVM the the Java 7 version shipped with MATLAB (Java 7).
+   Please refer to the support threads explaining how to change the JVM
+   software version used by MATLAB on
+   `Mac OS <https://uk.mathworks.com/matlabcentral/answers/103056-how-do-i-change-the-java-virtual-machine-jvm-that-matlab-is-using-on-macos>`__,
+   `Linux <https://uk.mathworks.com/matlabcentral/answers/130360-how-do-i-change-the-java-virtual-machine-jvm-that-matlab-is-using-for-linux>`__
+   or `Windows <https://uk.mathworks.com/matlabcentral/answers/130359-how-do-i-change-the-java-virtual-machine-jvm-that-matlab-is-using-on-windows>`__.
 
 Installation
 ------------
@@ -17,10 +27,6 @@ Download the MATLAB toolbox from the Bio-Formats
 `downloads page <https://www.openmicroscopy.org/bio-formats/downloads/>`_.
 Unzip :file:`bfmatlab.zip` and add the unzipped :file:`bfmatlab` folder to
 your MATLAB path.
-
-.. note:: As of Bio-Formats 5.0.0, this zip now contains the bundled jar
-    and you no longer need to download :file:`loci_tools.jar` or the new
-    :file:`bioformats_package.jar` separately.
 
 Usage
 -----

--- a/sphinx/users/matlab/index.rst
+++ b/sphinx/users/matlab/index.rst
@@ -13,9 +13,8 @@ image files. Note the minimum recommended MATLAB version is R2017b.
 .. note::
 
    It is possible to run Bio-Formats 6 on earlier MATLAB versions using a
-   the JVM the the Java 7 version shipped with MATLAB (Java 7).
-   Please refer to the support threads explaining how to change the JVM
-   software version used by MATLAB on
+   JVM version 8 or greater. Please refer to the support threads explaining
+   how to change the JVM software used by MATLAB for
    `Mac OS <https://uk.mathworks.com/matlabcentral/answers/103056-how-do-i-change-the-java-virtual-machine-jvm-that-matlab-is-using-on-macos>`__,
    `Linux <https://uk.mathworks.com/matlabcentral/answers/130360-how-do-i-change-the-java-virtual-machine-jvm-that-matlab-is-using-for-linux>`__
    or `Windows <https://uk.mathworks.com/matlabcentral/answers/130359-how-do-i-change-the-java-virtual-machine-jvm-that-matlab-is-using-on-windows>`__.


### PR DESCRIPTION
See [ome-devel thread](http://lists.openmicroscopy.org.uk/pipermail/ome-devel/2019-February/004331.html)

Recommend R2017b as the minimum version but document official support threads for using older versions of MATLAB with a local JVM 8 or above.