### PR TITLE
Remove link to large zip with MicroCT datasets

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -732,7 +732,7 @@ Note that the Gatan Reader does not currently support stacks.
 extensions = .vff
 developer = `GE <https://gelifesciences.com/>`_
 bsd = no
-weHave = * several `public MicroCT datasets <http://www.sci.utah.edu/~datasets/CTarchive.zip>`_ from the `CIBC Dataset Archive <http://www.sci.utah.edu/cibc-software/cibc-datasets.html>`_
+weHave = * several public MicroCT datasets from the `CIBC Dataset Archive <http://www.sci.utah.edu/cibc-software/cibc-datasets.html>`_
 pixelsRating = Very good
 metadataRating = Fair
 opennessRating = Fair


### PR DESCRIPTION
As discussed with @ome/formats, linking to a large file seems to slow down the docs build.  This removes the direct link to the problematic Zip, but keeps the link to the landing page.