### PR TITLE
Refine latest redirect mapping depending on the SNAPSHOT version

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -178,8 +178,18 @@ else:
 
 # Bio-Formats downloads
 if bf_version.endswith('SNAPSHOT'):
-    minor_version = ".".join(bf_version.split(".")[:2])
-    bf_downloads_root = downloads_root + '/latest/bio-formats%s/' % minor_version
+    v = bf_version.split(".")
+    if v[2] == "0-SNAPSHOT":
+        if v[1] == "0":
+            # x.0.0-SNAPHOT should point at /latest/bio-formats/
+            suffix = ""
+        else:
+            # x.y.0-SNAPHOT should point at /latest/bio-formatsx/
+            suffix = v[0]
+    else:
+        # x.y.z-SNAPHOT should point at /latest/bio-formatsx.y/
+        suffix = ".".join(v[:2])
+    bf_downloads_root = downloads_root + '/latest/bio-formats%s/' % suffix
 else:
     bf_downloads_root = downloads_root + '/bio-formats/%s/' % bf_version
 


### PR DESCRIPTION
When starting work on a minor or a major series, this allows the documentation to point at the latest redirects which is guaranteed to exist using the SNAPSHOT version i.e.

- `X.Y.Z-SNAPSHOT` -> `latest/bio-formatsX.Y/`
- `X.Y.0-SNAPSHOT` -> `latest/bio-formatsX/`
- `X.0.0-SNAPSHOT` -> `latest/bio-formats/`

Without this change and with #89, https://web-proxy.openmicroscopy.org/east-ci/job/BIOFORMATS-merge-docs/371/ was linking to https://downloads.openmicroscopy.org/latest/bio-formats6.1 which does not exist yet. With this change, the logic should detect the minor version increment and  point at https://downloads.openmicroscopy.org/latest/bio-formats6/ instead.