### PR TITLE
Add new format page for BDV

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -338,7 +338,7 @@ mif = true
 
 [Big Data Viewer]
 extensions = .xml, .h5
-owner = `Tobias Pietzsch <https://imagej.net/BigDataViewer/>`_
+owner = `Tobias Pietzsch <https://imagej.net/BigDataViewer>`_
 bsd = no
 weHave = * a BDV specification document \n
 * a number of sample BDV datasets

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -336,6 +336,21 @@ privateSpecification = true
 reader = SDTReader
 mif = true
 
+[Big Data Viewer]
+extensions = .xml, .h5
+owner = `Tobias Pietzsch <https://imagej.net/BigDataViewer/>`_
+bsd = no
+weHave = * a BDV specification document \n
+* a number of sample BDV datasets
+pixelsRating = Good
+metadataRating = Good
+opennessRating = Very Good
+presenceRating = Good
+utilityRating = Good
+pyramid = yes
+reader = BDVReader
+mif = true
+
 [Bio-Rad Gel]
 extensions = .1sc
 owner = `Bio-Rad <http://www.bio-rad.com>`_


### PR DESCRIPTION
New format page for Big Data Viewer

Ratings are based on https://docs.openmicroscopy.org/bio-formats/5.9.2/supported-formats.html#term-ratings-legend-and-definitions