### PR TITLE
Bump component versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,13 +23,13 @@
   </licenses>
 
   <properties>
-    <ome-common.version>6.0.2</ome-common.version>
+    <ome-common.version>6.0.3</ome-common.version>
     <ome-model.version>6.0.1</ome-model.version>
-    <bioformats.version>6.1.0-m2</bioformats.version>
+    <bioformats.version>6.1.0</bioformats.version>
     <formats-gpl.version>${bioformats.version}</formats-gpl.version>
     <formats-bsd.version>${bioformats.version}</formats-bsd.version>
     <formats-api.version>${bioformats.version}</formats-api.version>
-    <bio-formats-examples.version>6.1.0-m1</bio-formats-examples.version>
+    <bio-formats-examples.version>6.1.0</bio-formats-examples.version>
     <logback.version>1.1.1</logback.version>
 
     <sphinx.bioformats.source.branch>develop</sphinx.bioformats.source.branch>


### PR DESCRIPTION
Bumping the component versions prior to 6.1.0 release
Bio-Formats bump is need for https://github.com/ome/bio-formats-documentation/pull/100