### PR TITLE
Bumping documentation version to 6.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>bio-formats-documentation</artifactId>
-  <version>6.1.0-SNAPSHOT</version>
+  <version>6.1.0</version>
 
   <name>Bio-Formats documentation</name>
   <description>Bio-Formats Sphinx documentation</description>


### PR DESCRIPTION
Bumping `bio-formats-documentation` version to 6.1.0