### PR TITLE
Add new formats - Mikroscan and Ventana

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,11 +25,11 @@
   <properties>
     <ome-common.version>6.0.3</ome-common.version>
     <ome-model.version>6.0.1</ome-model.version>
-    <bioformats.version>6.1.1</bioformats.version>
+    <bioformats.version>6.2.0</bioformats.version>
     <formats-gpl.version>${bioformats.version}</formats-gpl.version>
     <formats-bsd.version>${bioformats.version}</formats-bsd.version>
     <formats-api.version>${bioformats.version}</formats-api.version>
-    <bio-formats-examples.version>6.1.1</bio-formats-examples.version>
+    <bio-formats-examples.version>6.2.0</bio-formats-examples.version>
     <logback.version>1.1.1</logback.version>
 
     <sphinx.bioformats.source.branch>develop</sphinx.bioformats.source.branch>

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -2500,7 +2500,6 @@ metadataRating = Good
 opennessRating = Fair
 presenceRating = Fair
 utilityRating = Good
-privateSpecification = true
 pyramid = yes
 reader = VentanaReader
 

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -1520,6 +1520,20 @@ notes = - Bio-Formats will recognize a :file:`*metadata.txt` file as part of a\n
   fileset and therefore the extended Micro-Manager metadata will be skipped.\n
 - See :doc:`/users/micromanager/index` for more information.
 
+[Mikroscan TIFF]
+extensions = .tif, .tiff
+owner = `Mikroscan <https://www.mikroscan.com/>`_
+bsd = no
+weHave = * some Mikroscan datasets
+pixelsRating = Good
+metadataRating = Good
+opennessRating = Good
+presenceRating = Fair
+utilityRating = Fair
+privateSpecification = true
+pyramid = yes
+reader = MikroscanTiffReader
+
 [MINC MRI]
 extensions = .mnc
 developer = `McGill University <http://www.bic.mni.mcgill.ca/ServicesSoftware/MINC>`_
@@ -2475,6 +2489,20 @@ opennessRating = Very Good
 presenceRating = Fair
 utilityRating = Good
 reader = VeecoReader
+
+[Ventana BIF]
+extensions = .bif
+owner = `Roche Digital Diagnostics <https://diagnostics.roche.com/global/en/home.html/>`_
+bsd = no
+weHave = * some Ventana datasets
+pixelsRating = Good
+metadataRating = Good
+opennessRating = Fair
+presenceRating = Fair
+utilityRating = Good
+privateSpecification = true
+pyramid = yes
+reader = VentanaReader
 
 [VG SAM]
 extensions = .dti


### PR DESCRIPTION
Add 2 new formats for 6.2.0 - Mikroscan Tiff and Ventana Bif

Format Ratings are based on https://docs.openmicroscopy.org/bio-formats/5.9.2/supported-formats.html#term-ratings-legend-and-definitions