### PR TITLE
Document all known JPEG2000 suffixes

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -1171,7 +1171,7 @@ utilityRating = Fair
 reader = JEOLReader
 
 [JPEG 2000]
-extensions = .jp2
+extensions = .jp2, .j2k, .jpf
 developer = `Independent JPEG Group <http://www.ijg.org/>`_
 bsd = yes
 software = `JJ2000 (JPEG 2000 library for Java) <https://code.google.com/archive/p/jj2000/>`_


### PR DESCRIPTION
Noticed while working on https://github.com/ome/bioformats/pull/3445

Our format pages only indicate a subset of the file extensions that would be detected as JPEG2000 files.