### PR TITLE
Gen test images: Add options for sleeping

### DIFF
--- a/sphinx/developers/generating-test-images.rst
+++ b/sphinx/developers/generating-test-images.rst
@@ -306,7 +306,7 @@ with their default values, is shown below.
         pyramid levels
       * 2
     - * sleepOpenBytes
-      * umber of milliseconds to sleep for when openBytes is called 
+      * number of milliseconds to sleep for when openBytes is called 
       * 0
     - * sleepInitFile
       * number of milliseconds to sleep for when initFile is called 

--- a/sphinx/developers/generating-test-images.rst
+++ b/sphinx/developers/generating-test-images.rst
@@ -305,6 +305,12 @@ with their default values, is shown below.
       * for images with sub-resolutions, scaling factor between consecutive
         pyramid levels
       * 2
+    - * sleepOpenBytes
+      * umber of milliseconds to sleep for when openBytes is called 
+      * 0
+    - * sleepInitFile
+      * number of milliseconds to sleep for when initFile is called 
+      * 0
 
 .. [1] Default value set to 1 if any of the ``screens``, ``plates``,
        ``plateAcqs``, ``plateRows``, ``plateCols`` or ``fields`` values is set


### PR DESCRIPTION
This is a follow up PR to the recently merged https://github.com/ome/bioformats/pull/3422