### PR TITLE
Fix broken Perkin-Elmer links

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -432,5 +432,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://www.nis-elements.com/.*', # Invalid SSL certificate
     r'https://www.nikoninstruments.com/.*', # Invalid SSL certificate
     r'http://farsight-toolkit.ee.uh.edu/.*',
-    r'https://testng.org/*' # Invalid SSL certificate
+    r'https://testng.org/*', # Invalid SSL certificate
+    r'http://www.bio-rad.com/*' # 503 Server Error with Sphinx v1.8.5
 ]

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -857,7 +857,7 @@ reader = HitachiReader
 
 [I2I]
 extensions = .i2i
-developer = `Biomedical Imaging Group, UMass Medical School <http://invitro.umassmed.edu/>`_
+developer = `Biomedical Imaging Group, UMass Medical School <http://umassmed.edu/>`_
 bsd = no
 weHave = * several example datasets \n
 * a specification document \n

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -983,7 +983,7 @@ reader = IMODReader
 [Improvision Openlab LIFF]
 extensions = .liff
 owner = `PerkinElmer <http://www.perkinelmer.com/>`_
-developer = `Improvision <https://www.perkinelmer.com/lab-products-and-services/resources/cellular-imaging-software-downloads.html>`_
+developer = `Improvision <https://www.perkinelmer.com/lab-products-and-services/resources/software-downloads.html>`_
 bsd = no
 versions = 2.0, 5.0
 weHave = * an Openlab specification document (from 2000 February 8, in DOC) \n
@@ -1002,7 +1002,7 @@ mif = true
 [Improvision Openlab Raw]
 extensions = .raw
 owner = `PerkinElmer <http://www.perkinelmer.com/>`_
-developer = `Improvision <https://www.perkinelmer.com/lab-products-and-services/resources/cellular-imaging-software-downloads.html>`_
+developer = `Improvision <https://www.perkinelmer.com/lab-products-and-services/resources/software-downloads.html>`_
 bsd = no
 weHave = * an Openlab Raw specification document (from 2004 November 09, in HTML) \n
 * a few Openlab Raw datasets
@@ -1016,7 +1016,7 @@ reader = OpenlabRawReader
 [Improvision TIFF]
 extensions = .tif
 owner = `PerkinElmer <http://www.perkinelmer.com/>`_
-developer = `Improvision <https://www.perkinelmer.com/lab-products-and-services/resources/cellular-imaging-software-downloads.html>`_
+developer = `Improvision <https://www.perkinelmer.com/lab-products-and-services/resources/software-downloads.html>`_
 bsd = no
 weHave = * an Improvision TIFF specification document \n
 * a few Improvision TIFF datasets

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -1004,7 +1004,7 @@ extensions = .raw
 owner = `PerkinElmer <http://www.perkinelmer.com/>`_
 developer = `Improvision <https://www.perkinelmer.com/lab-products-and-services/resources/cellular-imaging-software-downloads.html>`_
 bsd = no
-weHave = * an `Openlab Raw specification document (from 2004 November 09, in HTML) \n
+weHave = * an Openlab Raw specification document (from 2004 November 09, in HTML) \n
 * a few Openlab Raw datasets
 pixelsRating = Outstanding
 metadataRating = Very good

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -983,7 +983,7 @@ reader = IMODReader
 [Improvision Openlab LIFF]
 extensions = .liff
 owner = `PerkinElmer <http://www.perkinelmer.com/>`_
-developer = `Improvision <http://www.perkinelmer.com/lab-products-and-services/cellular-imaging/index.html>`_
+developer = `Improvision <https://www.perkinelmer.com/lab-products-and-services/resources/cellular-imaging-software-downloads.html>`_
 bsd = no
 versions = 2.0, 5.0
 weHave = * an Openlab specification document (from 2000 February 8, in DOC) \n
@@ -1002,9 +1002,9 @@ mif = true
 [Improvision Openlab Raw]
 extensions = .raw
 owner = `PerkinElmer <http://www.perkinelmer.com/>`_
-developer = `Improvision <http://www.perkinelmer.com/lab-products-and-services/cellular-imaging/index.html>`_
+developer = `Improvision <https://www.perkinelmer.com/lab-products-and-services/resources/cellular-imaging-software-downloads.html>`_
 bsd = no
-weHave = * an `Openlab Raw specification document <http://cellularimaging.perkinelmer.com/support/technical_notes/detail.php?id=344>`_ (from 2004 November 09, in HTML) \n
+weHave = * an `Openlab Raw specification document (from 2004 November 09, in HTML) \n
 * a few Openlab Raw datasets
 pixelsRating = Outstanding
 metadataRating = Very good
@@ -1016,7 +1016,7 @@ reader = OpenlabRawReader
 [Improvision TIFF]
 extensions = .tif
 owner = `PerkinElmer <http://www.perkinelmer.com/>`_
-developer = `Improvision <http://www.perkinelmer.com/lab-products-and-services/cellular-imaging/index.html>`_
+developer = `Improvision <https://www.perkinelmer.com/lab-products-and-services/resources/cellular-imaging-software-downloads.html>`_
 bsd = no
 weHave = * an Improvision TIFF specification document \n
 * a few Improvision TIFF datasets
@@ -2538,7 +2538,7 @@ mif = true
 
 [Volocity Library Clipping]
 extensions = .acff
-developer = `PerkinElmer <http://www.perkinelmer.com/lab-products-and-services/cellular-imaging/>`_
+developer = `PerkinElmer <https://www.perkinelmer.com/lab-products-and-services/resources/cellular-imaging-software-downloads.html>`_
 bsd = no
 weHave = * several Volocity library clipping datasets
 weWant = * any datasets that do not open correctly \n
@@ -2553,7 +2553,7 @@ notes = RGB .acff files are not yet supported.  See :ticket:`6413`.
 
 [Volocity]
 extensions = .mvd2
-developer = `PerkinElmer <http://www.perkinelmer.com/lab-products-and-services/cellular-imaging/>`_
+developer = `PerkinElmer <https://www.perkinelmer.com/lab-products-and-services/resources/cellular-imaging-software-downloads.html>`_
 bsd = no
 samples = `PerkinElmer Downloads <http://cellularimaging.perkinelmer.com/downloads/>`_
 weHave = * many example Volocity datasets


### PR DESCRIPTION
Fixes for broken links. Note the Openlab RAW specification link is removed altogether as I have been unable to find a link to the tech paper since they updated the website (though there does still seem to be a lot of broken links and missing content on their site at the moment and the search is not returning anything).