### PR TITLE
Link to Biomedical Imaging Group site at UMassMed.

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -858,7 +858,7 @@ reader = HitachiReader
 
 [I2I]
 extensions = .i2i
-developer = `Biomedical Imaging Group, UMass Medical School <http://umassmed.edu/>`_
+developer = `Biomedical Imaging Group, UMass Medical School <http://big.umassmed.edu/>`_
 bsd = no
 weHave = * several example datasets \n
 * a specification document \n


### PR DESCRIPTION
Make I2I format link more specific.