### PR TITLE
Add mayo.edu to ignore list

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -433,5 +433,5 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://www.nikoninstruments.com/.*', # Invalid SSL certificate
     r'http://farsight-toolkit.ee.uh.edu/.*',
     r'https://testng.org/*', # Invalid SSL certificate
-    r'http://www.bio-rad.com/*' # 503 Server Error with Sphinx v1.8.5
+    r'https://www.mayo.edu/.*'
 ]

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -433,5 +433,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://www.nikoninstruments.com/.*', # Invalid SSL certificate
     r'http://farsight-toolkit.ee.uh.edu/.*',
     r'https://testng.org/*', # Invalid SSL certificate
+    r'http://www.bio-rad.com/*', # 503 Server Error with Sphinx v1.8.5  
     r'https://www.mayo.edu/.*'
 ]


### PR DESCRIPTION
Adding to ignore list as it regularly fails link check with the below error:
broken    https://www.mayo.edu/research/core-resources/biomedical-imaging-resource-core/overview - 403 Client Error: ModSecurity Action for url: https://www.mayo.edu/research/core-resources/biomedical-imaging-resource-core/overview