### PR TITLE
Update link for libjpeg-turbo

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -434,5 +434,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'http://farsight-toolkit.ee.uh.edu/.*',
     r'https://testng.org/*', # Invalid SSL certificate
     r'http://www.bio-rad.com/*', # 503 Server Error with Sphinx v1.8.5  
-    r'https://www.mayo.edu/.*'
+    r'https://www.mayo.edu/.*',
+    r'https://libjpeg-turbo.org'
 ]

--- a/sphinx/developers/components.rst
+++ b/sphinx/developers/components.rst
@@ -93,7 +93,7 @@ need to remove the conflicting JAR(s) as a workaround.
 
 `Ant: jar-turbojpeg`
 
-This is a fork of `libjpeg-turbo <https://libjpeg-turbo.org/>`_.
+This is a fork of `libjpeg-turbo <https://libjpeg-turbo.org>`_.
 There are not any real code changes, but having this as a separate component
 allows us to package the libjpeg-turbo Java API together with all of the
 required binaries into a single .jar file using `native-lib-loader

--- a/sphinx/developers/components.rst
+++ b/sphinx/developers/components.rst
@@ -93,7 +93,7 @@ need to remove the conflicting JAR(s) as a workaround.
 
 `Ant: jar-turbojpeg`
 
-This is a fork of `libjpeg-turbo <http://libjpeg-turbo.virtualgl.org/>`_.
+This is a fork of `libjpeg-turbo <https://libjpeg-turbo.org/>`_.
 There are not any real code changes, but having this as a separate component
 allows us to package the libjpeg-turbo Java API together with all of the
 required binaries into a single .jar file using `native-lib-loader


### PR DESCRIPTION
Fix for broken link in https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-build-docs/jdk=JDK8,label=testintegration/236/console