### PR TITLE
Update path to bio-formats tag on image.sc

### DIFF
--- a/sphinx/about/bug-reporting.rst
+++ b/sphinx/about/bug-reporting.rst
@@ -64,7 +64,7 @@ Sending a bug report
 If you can still reproduce the bug after updating to the latest version
 of Bio-Formats, and your issue does not relate to anything listed above or
 noted on the relevant file format page, please send a bug report to the
-:imagesc:`forums <tags/bio-formats>`. You can upload files to our
+:imagesc:`forums <tag/bio-formats>`. You can upload files to our
 `QA system <http://qa.openmicroscopy.org.uk/qa/upload/>`_ or for large files
 (>2 GB), we can provide you with an FTP server address if you write to the
 mailing list.

--- a/sphinx/about/index.rst
+++ b/sphinx/about/index.rst
@@ -47,7 +47,7 @@ command line tools, refer to the :doc:`users documentation </users/index>`.
 You can also find tips on common issues with specific formats on the
 pages linked from the :doc:`supported formats table </supported-formats>`.
 
-Please :imagesc:`contact us <tags/bio-formats>` if you have any questions or problems with
+Please :imagesc:`contact us <tag/bio-formats>` if you have any questions or problems with
 Bio-Formats not addressed by referring to the documentation.
 
 Other places where questions are commonly asked and/or bugs are reported

--- a/sphinx/developers/reader-guide.rst
+++ b/sphinx/developers/reader-guide.rst
@@ -307,4 +307,4 @@ Other useful things
   most straightforward one). :bfreader:`loci.formats.in.LIFReader <LIFReader.java>` and :bfreader:`InCellReader <InCellReader.java>` are also
   good references that show off some of the nicer features of Bio-Formats.
 
-If you have questions about Bio-Formats, please contact :imagesc:`the forums <tags/bio-formats>`.
+If you have questions about Bio-Formats, please contact :imagesc:`the forums <tag/bio-formats>`.

--- a/sphinx/index.rst
+++ b/sphinx/index.rst
@@ -24,7 +24,7 @@ release of the :model_doc:`OME Model <>`.
 **Bio-Formats is a community project and we welcome your input.** You can
 find guidance on :doc:`about/bug-reporting`, upload files to our
 `QA system <http://qa.openmicroscopy.org.uk/qa/upload/>`_ for testing, and
-:imagesc:`contact us <tags/bio-formats>` via the forums. Further
+:imagesc:`contact us <tag/bio-formats>` via the forums. Further
 information about how the OME team works and how you can contribute to our
 projects is in the :devs_doc:`Contributing Developer Documentation <>`.
 


### PR DESCRIPTION
Discourse changed from `/tags/...` to `/tag/...` recently. The old path still works, but you will only see the Bio-Formats sidebar description if you use the new path, so best to update it.