### PR TITLE
Linkcheck fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
+---
 language: java
-
-sudo: false
-
-# http://docs.travis-ci.com/user/caching/#Arbitrary-directories
 cache:
   directories:
   - $HOME/.m2
+
+addons:
+  apt:
+    packages:
+      - python3-pip
 
 jdk:
   - openjdk11
@@ -15,7 +17,7 @@ matrix:
   fast_finish: true
 
 before_install:
-  - pip install --user -r requirements.txt
+  - pip3 install --user -r requirements.txt
 
 script:
   - mvn install -DskipSphinxTests=true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,1 @@
-# Python requirements
-# ===================
-#
-#     pip install -r requirements.txt
-#
-Genshi==0.7
 Sphinx

--- a/sphinx/about/index.rst
+++ b/sphinx/about/index.rst
@@ -10,13 +10,13 @@ The primary goal of Bio-Formats is to facilitate the exchange of
 microscopy data between different software packages and
 organizations. It achieves this by converting proprietary
 microscopy data into an open standard called the `OME data
-model <http://genomebiology.com/2005/6/5/R47>`_, particularly into the
+model <https://genomebiology.com/2005/6/5/R47>`_, particularly into the
 :model_doc:`OME-TIFF <ome-tiff>` file format.
 
 We believe the standardization of microscopy metadata to a common
 structure is of vital importance to the community. You may find LOCI's article
 on `open source software in
-science <http://loci.wisc.edu/software/oss>`_ of interest.
+science <https://loci.wisc.edu/software/oss>`_ of interest.
 
 License, copyright, and citation
 --------------------------------
@@ -33,7 +33,7 @@ Bio-Formats can be cited in publications as follows:
 
   Melissa Linkert, Curtis T. Rueden, Chris Allan, Jean-Marie Burel, Will Moore, Andrew Patterson, Brian Loranger, Josh Moore, Carlos Neves, Donald MacDonald, Aleksandra Tarkowska, Caitlin Sticco, Emma Hill, Mike Rossner, Kevin W. Eliceiri, and Jason R. Swedlow (2010) Metadata matters: access to image data in the real world. The Journal of Cell Biology 189(5), 777-782. doi: 10.1083/jcb.201004104
 
-`PMID:20513764 <http://www.ncbi.nlm.nih.gov/pubmed/20513764>`_
+`PMID:20513764 <https://www.ncbi.nlm.nih.gov/pubmed/20513764>`_
 
 Additional citation information can be found on the :oo_root:`main OME citation page <citing-ome>`.
 
@@ -56,16 +56,16 @@ include:
 -  :community:`OME Forums <>`
 -  `OME Trac <https://trac.openmicroscopy.org/ome>`_
 -  `ome-devel mailing
-   list <http://lists.openmicroscopy.org.uk/pipermail/ome-devel>`_
+   list <https://lists.openmicroscopy.org.uk/pipermail/ome-devel>`_
    (searchable using google with 'site:lists.openmicroscopy.org.uk')
 -  `ome-users mailing
-   list <http://lists.openmicroscopy.org.uk/pipermail/ome-users>`_
+   list <https://lists.openmicroscopy.org.uk/pipermail/ome-users>`_
    (searchable using google with 'site:lists.openmicroscopy.org.uk')
 -  `ImageJ mailing list <http://imagej.nih.gov/ij/list.html>`_ (and
    `archive <http://imagej.1557.x6.nabble.com/>`_)
 -  `Fiji GitHub Issues <https://github.com/fiji/fiji/issues>`_
 -  `Confocal microscopy mailing
-   list <http://lists.umn.edu/cgi-bin/wa?A0=confocalmicroscopy>`_
+   list <https://lists.umn.edu/cgi-bin/wa?A0=confocalmicroscopy>`_
 
 Bio-Formats versions
 --------------------
@@ -138,13 +138,13 @@ compiled one time into platform-independent byte code, which can be deployed
 as is to all supported platforms. And despite this enormous flexibility, Java
 manages to provide time performance nearly equal to C++, often better in the
 case of I/O operations (see further discussion on the
-`comparative speed of Java on the LOCI site <http://loci.wisc.edu/faq/isnt-java-too-slow>`_).
+`comparative speed of Java on the LOCI site <https://loci.wisc.edu/faq/isnt-java-too-slow>`_).
 
 There are also historical reasons associated with the fact that the project
 grew out of work on the
 `VisAD Java component library <http://visad.ssec.wisc.edu>`_. You can read
 more about the origins of Bio-Formats on the
-`LOCI Bio-Formats homepage <http://loci.wisc.edu/software/bio-formats>`_.
+`LOCI Bio-Formats homepage <https://loci.wisc.edu/software/bio-formats>`_.
 
 Bio-Formats metadata processing
 -------------------------------
@@ -159,7 +159,7 @@ available today.
 Every file format has a distinct set of metadata, stored differently.
 Bio-Formats processes and converts each format's metadata structures
 into a standard form called the `OME data
-model <http://genomebiology.com/2005/6/5/R47>`_, according to the
+model <https://genomebiology.com/2005/6/5/R47>`_, according to the
 :model_doc:`OME-XML <ome-xml>` specification. We have defined an open exchange
 format called :model_doc:`OME-TIFF <ome-tiff>` that stores its metadata as
 OME-XML. Any software package that supports OME-TIFF is also compatible with

--- a/sphinx/about/index.rst
+++ b/sphinx/about/index.rst
@@ -10,7 +10,7 @@ The primary goal of Bio-Formats is to facilitate the exchange of
 microscopy data between different software packages and
 organizations. It achieves this by converting proprietary
 microscopy data into an open standard called the `OME data
-model <https://genomebiology.com/2005/6/5/R47>`_, particularly into the
+model <http://genomebiology.com/2005/6/5/R47>`_, particularly into the
 :model_doc:`OME-TIFF <ome-tiff>` file format.
 
 We believe the standardization of microscopy metadata to a common
@@ -159,7 +159,7 @@ available today.
 Every file format has a distinct set of metadata, stored differently.
 Bio-Formats processes and converts each format's metadata structures
 into a standard form called the `OME data
-model <https://genomebiology.com/2005/6/5/R47>`_, according to the
+model <http://genomebiology.com/2005/6/5/R47>`_, according to the
 :model_doc:`OME-XML <ome-xml>` specification. We have defined an open exchange
 format called :model_doc:`OME-TIFF <ome-tiff>` that stores its metadata as
 OME-XML. Any software package that supports OME-TIFF is also compatible with

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -437,5 +437,5 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://www.mayo.edu/.*',
     r'https://libjpeg-turbo.org',
     r'https://www.biovis.com/.*', # SSLV3_ALERT_HANDSHAKE_FAILURE
-    r'https://www.github.com/ome/.*', # 429 too many requests for url
+    r'https://github.com/ome/.*', # 429 too many requests for url
 ]

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -437,4 +437,5 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://www.mayo.edu/.*',
     r'https://libjpeg-turbo.org',
     r'https://www.biovis.com/.*', # SSLV3_ALERT_HANDSHAKE_FAILURE
+    r'https://www.github.com/ome/.*', # 429 too many requests for url
 ]

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -435,5 +435,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://testng.org/*', # Invalid SSL certificate
     r'http://www.bio-rad.com/*', # 503 Server Error with Sphinx v1.8.5  
     r'https://www.mayo.edu/.*',
-    r'https://libjpeg-turbo.org'
+    r'https://libjpeg-turbo.org',
+    r'https://www.biovis.com/.*', # SSLV3_ALERT_HANDSHAKE_FAILURE
 ]

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -109,7 +109,7 @@ pygments_style = 'sphinx'
 #modindex_common_prefix = []
 
 github_root = 'https://github.com/'
-bf_github_root = github_root + openmicroscopy_source_user + '/bioformats/'
+bf_github_root = github_root + ome_source_user + '/bioformats/'
 bf_github_tree = bf_github_root + 'tree/' + bioformats_source_branch + '/'
 bf_github_blob = bf_github_root + 'blob/' + bioformats_source_branch + '/'
 gpl_formats = bf_github_blob + 'components/formats-gpl/src/loci/formats/'

--- a/sphinx/developers/building-bioformats.rst
+++ b/sphinx/developers/building-bioformats.rst
@@ -20,8 +20,7 @@ This may be accessed using the repository path::
 
 More information about Git and client downloads are available from the
 `Git project website <https://git-scm.com/>`_.  You can also browse the
-`Bio-Formats source on GitHub
-<https://github.com/openmicroscopy/bioformats>`_
+`Bio-Formats source on GitHub <https://github.com/ome/bioformats>`_
 
 .. note::
 

--- a/sphinx/developers/components.rst
+++ b/sphinx/developers/components.rst
@@ -229,7 +229,7 @@ allows OLE files to be read from memory.
 `Metakit Java library <https://github.com/ome/ome-metakit/tree/master>`_:
 
 Java implementation of the `Metakit database specification
-<https://equi4.com/metakit/>`_.  This uses classes from
+<https://wiki.tcl-lang.org/page/Metakit/>`_.  This uses classes from
 :ref:`ome-common <ome-common>` and is used by
 :ref:`formats-gpl <formats-gpl>`, but is otherwise independent of the main
 Bio-Formats API.

--- a/sphinx/developers/java-library.rst
+++ b/sphinx/developers/java-library.rst
@@ -12,7 +12,7 @@ enable the use of this repository.
 
 Examples of getting started with Bio-Formats using Maven or Gradle are given
 in the https://github.com/ome/bio-formats-examples repository.
-`OMERO <https://github.com/openmicroscopy/openmicroscopy>`_ uses Ivy to manage
+`OMERO <https://github.com/ome/openmicroscopy>`_ uses Ivy to manage
 its Java dependencies including Bio-Formats.
 
 .. note::

--- a/sphinx/users/ome-server/index.rst
+++ b/sphinx/users/ome-server/index.rst
@@ -112,7 +112,7 @@ three languages, using piped system calls in both directions to
 communicate, with imported pixels written to OMEIS pixels files. The
 relevant source files are:
 
--  `OmeisImporter.java <https://github.com/openmicroscopy/bioformats/tree/v4.4.10/components/scifio/src/loci/formats/ome/OmeisImporter.java>`_
+-  `OmeisImporter.java <https://github.com/ome/bioformats/tree/v4.4.10/components/scifio/src/loci/formats/ome/OmeisImporter.java>`_
    – omebf Java command line tool
 -  `BioFormats.pm <http://downloads.openmicroscopy.org/ome/code/BioFormats.pm>`_
    – Perl module for OME Bio-Formats importer

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -2566,7 +2566,7 @@ presenceRating = Poor
 utilityRating = Fair
 reader = VolocityReader
 mif = true
-notes = .mvd2 files are `Metakit database files <https://equi4.com/metakit/>`_.
+notes = .mvd2 files are `Metakit database files <https://wiki.tcl-lang.org/page/Metakit/>`_.
 
 [WA-TOP]
 extensions = .wat

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -2168,7 +2168,7 @@ mif = true
 
 [Quesant]
 extensions = .afm
-owner = `KLA-Tencor Corporation <https://www.kla-tencor.com/products/surface-profilers>`_
+owner = `KLA-Tencor Corporation <https://www.kla-tencor.com/>`_
 developer = Quesant Instrument Corporation
 bsd = no
 weHave = * Pascal code that can read Quesant files (from ImageSXM) \n


### PR DESCRIPTION
This aims at fixing long-running issues with the Bio-Formats documentation job.

For testing, the previous BIOFORMATS-build-docs CI job has been updated by a more straightforward BIOFORMATS-linkcheck one which consumes the Docker image built from https://github.com/ome/bio-formats-build and runs the linkcheck step. This should also use a Python 3 environment and thus benefit from the latest version of Sphinx