### PR TITLE
Update OME GitHub links for the relocated repositories.

### DIFF
--- a/sphinx/about/index.rst
+++ b/sphinx/about/index.rst
@@ -122,7 +122,7 @@ For format reader fixes and additions, the policy should read as follows:
 - The patch version Z MUST be incremented if only backwards-compatible format
   bug fixes are introduced.
 
-See `this GitHub issue <https://github.com/openmicroscopy/design/issues/55>`_
+See `this GitHub issue <https://github.com/ome/design/issues/55>`_
 for further details.
 
 Why Java?

--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -873,7 +873,7 @@ Bug fixes and improvements:
 
 Documentation improvements:
 
-* added a `support <https://github.com/openmicroscopy/bioformats/blob/develop/SUPPORT.md>`_ 
+* added a `support <https://github.com/ome/bioformats/blob/develop/SUPPORT.md>`_ 
   page to the Bio-Formats project
 * updated reference URLs for the Aperio ImageScope and Micro-Manager
 * documented issues with conflicts in the :ref:`JAI ImageIO component <forks-jai>`
@@ -1667,7 +1667,7 @@ Top-level Bio-Formats API changes:
 * the Formats API has also been updated to add a new validate property to
   ``MetadataOptions`` and support for ``MetadataOptions`` has been moved to
   FormatHandler level to allow it to be used by both Readers and Writers
-* initial work on `Reader discoverability <https://github.com/openmicroscopy/design/issues/42>`_
+* initial work on `Reader discoverability <https://github.com/ome/design/issues/42>`_
   extended the ClassList API to allow the :file:`readers.txt` configuration
   file to be annotated using key/value pairs to mark optional Readers and
   specify additional per-Reader options


### PR DESCRIPTION
Adjust a couple of links in our GitHub documentation to point to our relocated repositories. Should benefit from #151.