### PR TITLE
Convert format-documentation page glossary into definition list

### DIFF
--- a/sphinx/developers/format-documentation.rst
+++ b/sphinx/developers/format-documentation.rst
@@ -18,9 +18,7 @@ page for all supported formats using Velocity_.
 
 The :file:`format-pages.txt` is an INI file where each section corresponds to
 a particular format given by the section header. Multiple key/values should be
-defined for each section:
-
-.. glossary::
+defined for each section::
 
   pagename
     The name of the output reStructuredText file. If unspecified, the section


### PR DESCRIPTION
Sphinx 3.0.0 released yesterday throws warnings on duplicate glossary keys including lowercase variations (`bsd` vs `BSD`) - see https://github.com/sphinx-doc/sphinx/issues/7418

This has broken the daily [BIOFORMATS-image](https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-image/360/) job