### PR TITLE
Fix formatting of anchors for OME-XML Javadoc

### DIFF
--- a/sphinx/developers/file-reader.rst
+++ b/sphinx/developers/file-reader.rst
@@ -85,7 +85,7 @@ from the OME-XML Metadata. These fields can be accessed in a similar way to the 
 An example of such values would be the physical size of dimensions X, Y and Z. The accessor methods 
 for these properties return a :xml_javadoc:`Length <ome/units/quantity/Length.html>` object which 
 contains both the value and unit of the dimension. These lengths can also be converted to other units using 
-:xml_javadoc:`value(ome.units.unit.Unit) <ome/units/quantity/Length.html#value-ome.units.unit.Unit->`
+:xml_javadoc:`value(ome.units.unit.Unit) <ome/units/quantity/Length.html#value(ome.units.unit.Unit)>`
 An example of reading and converting these physical sizes values can be found in 
 :download:`ReadPhysicalSize.java <examples/ReadPhysicalSize.java>`
 


### PR DESCRIPTION
See https://javadoc.io/static/org.openmicroscopy/ome-xml/6.1.0/ome/units/quantity/Length.html#value(ome.units.unit.Unit) vs https://javadoc.io/static/org.openmicroscopy/ome-xml/6.0.1/ome/units/quantity/Length.html#value-ome.units.unit.Unit-

This should fix the broken links since the publishing of the Javadoc for the newest release of ome-model.

For the release documentation, this PR effectively depends on https://github.com/ome/bioformats/pull/3545.

