### PR TITLE
Fix broken Bitplane links

### DIFF
--- a/sphinx/users/imaris/index.rst
+++ b/sphinx/users/imaris/index.rst
@@ -9,7 +9,7 @@ provides a complete set of features for working with three- and
 four-dimensional multi-channel images of any size, from a few megabytes
 to multiple gigabytes in size.
 
-As of `version
+As of version
 7.2,
 Imaris integrates with :doc:`/users/fiji/index`, which includes
 Bio-Formats. See `this

--- a/sphinx/users/imaris/index.rst
+++ b/sphinx/users/imaris/index.rst
@@ -1,7 +1,7 @@
 Bitplane Imaris
 ===============
 
-`Imaris <http://www.bitplane.com/>`_ is Bitplane's core scientific
+`Imaris <https://imaris.oxinst.com/>`_ is Bitplane's core scientific
 software module that delivers all the necessary functionality for data
 visualization, analysis, segmentation and interpretation of 3D and 4D
 microscopy datasets. Combining speed, precision and ease-of-use, Imaris
@@ -10,8 +10,8 @@ four-dimensional multi-channel images of any size, from a few megabytes
 to multiple gigabytes in size.
 
 As of `version
-7.2 <http://www.bitplane.com/releasenotes.aspx?product=Imaris&version=7.2&patch=0>`_,
+7.2,
 Imaris integrates with :doc:`/users/fiji/index`, which includes
 Bio-Formats. See `this
-page <http://www.bitplane.com/imaris/imaris>`_ for a detailed list of Imaris'
+page <https://imaris.oxinst.com/packages/>`_ for a detailed list of Imaris'
 features.

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -422,7 +422,7 @@ owner = `Bitplane <https://imaris.oxinst.com/>`_
 bsd = no
 versions = 2.7, 3.0, 5.5
 weHave = * an `Imaris (RAW) specification document (from no later than 1997 November 11, in HTML) \n
-* an `Imaris 5.5 (HDF) specification document \n
+* an Imaris 5.5 (HDF) specification document \n
 * Bitplane's bfFileReaderImaris3N code (from no later than 2005, in C++) \n
 * several older Imaris (RAW) datasets \n
 * one Imaris 3 (TIFF) dataset \n
@@ -2731,4 +2731,3 @@ Commercial applications that support this format include: \n
 * `Bitplane Imaris <http://www.bitplane.com/>`_ \n
 * `Amira <https://www.fei.com/software/amira-avizo/>`_ \n
 * `Image-Pro Plus <http://www.mediacy.com/>`_
-

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -418,11 +418,11 @@ reader = BioRadSCNReader
 
 [Bitplane Imaris]
 extensions = .ims
-owner = `Bitplane <http://www.bitplane.com/>`_
+owner = `Bitplane <https://imaris.oxinst.com/>`_
 bsd = no
 versions = 2.7, 3.0, 5.5
-weHave = * an `Imaris (RAW) specification document <http://flash.bitplane.com/wda/interfaces/public/faqs/faqsview.cfm?inCat=0&inQuestionID=104>`_ (from no later than 1997 November 11, in HTML) \n
-* an `Imaris 5.5 (HDF) specification document <http://open.bitplane.com/Default.aspx?tabid=268>`_ \n
+weHave = * an `Imaris (RAW) specification document (from no later than 1997 November 11, in HTML) \n
+* an `Imaris 5.5 (HDF) specification document \n
 * Bitplane's bfFileReaderImaris3N code (from no later than 2005, in C++) \n
 * several older Imaris (RAW) datasets \n
 * one Imaris 3 (TIFF) dataset \n

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -421,7 +421,7 @@ extensions = .ims
 owner = `Bitplane <https://imaris.oxinst.com/>`_
 bsd = no
 versions = 2.7, 3.0, 5.5
-weHave = * an `Imaris (RAW) specification document (from no later than 1997 November 11, in HTML) \n
+weHave = * an Imaris (RAW) specification document (from no later than 1997 November 11, in HTML) \n
 * an Imaris 5.5 (HDF) specification document \n
 * Bitplane's bfFileReaderImaris3N code (from no later than 2005, in C++) \n
 * several older Imaris (RAW) datasets \n

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -418,7 +418,7 @@ reader = BioRadSCNReader
 
 [Bitplane Imaris]
 extensions = .ims
-owner = `Bitplane <https://imaris.oxinst.com/>`_
+owner = `Oxford Instruments <https://imaris.oxinst.com/>`_ (formerly Bitplane)
 bsd = no
 versions = 2.7, 3.0, 5.5
 weHave = * an Imaris (RAW) specification document (from no later than 1997 November 11, in HTML) \n


### PR DESCRIPTION
Initial fix for broken Bitplane links. If the Bitplane site is gone for good then this PR may be updated to change the name from `Bitplane Imaris` to `Oxford Instruments Imaris`.