### PR TITLE
Fix various hyperlinks.

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -425,7 +425,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://www.fei.com/.*',
     r'https?://www.ionpath.com/.*',
     r'http://www.scanco.ch/',
-    r'https://www.slf4j.org/',
     'http://cellularimaging.perkinelmer.com/downloads/',
     'https://animatedpngs.com/', # SSL certificate error
     'https://www.merckmillipore.com', # Read timeout

--- a/sphinx/developers/java-library.rst
+++ b/sphinx/developers/java-library.rst
@@ -29,7 +29,7 @@ You can :downloads:`download formats-gpl.jar <artifacts/formats-gpl.jar>` to
 use it as a library. Just add :file:`formats-gpl.jar` to your CLASSPATH or
 build path. You will also need :file:`ome-common.jar` for common I/O functions,
 :file:`ome-xml.jar` for metadata standardization, and
-`SLF4J <https://www.slf4j.org/>`_ for :doc:`logging`.
+`SLF4J <http://www.slf4j.org/>`_ for :doc:`logging`.
 
 Dependencies
 ^^^^^^^^^^^^
@@ -120,10 +120,10 @@ The complete list of current dependencies is as follows:
     * - `Native Library Loader v2.1.4 <https://github.com/scijava/native-lib-loader>`_
       - org.scijava:native-lib-loader:2.1.4
       - `BSD License`_
-    * - `SLF4J API v1.7.4 <https://www.slf4j.org>`_
+    * - `SLF4J API v1.7.4 <http://www.slf4j.org>`_
       - org.slf4j:slf4j-api:1.7.6
       - `MIT License`_
-    * - `SLF4J LOG4J-12 Binding v1.7.6 <https://www.slf4j.org>`_
+    * - `SLF4J LOG4J-12 Binding v1.7.6 <http://www.slf4j.org>`_
       - org.slf4j:slf4j-log4j12:1.7.6
       - `MIT License`_
     * - `TestNG v6.8 <https://testng.org/doc/>`_

--- a/sphinx/developers/logging.rst
+++ b/sphinx/developers/logging.rst
@@ -4,7 +4,7 @@ Logging
 Logging frameworks
 ------------------
 
-Bio-Formats uses `SLF4J <https://www.slf4j.org>`_ as a logging API. SLF4J is a
+Bio-Formats uses `SLF4J <http://www.slf4j.org>`_ as a logging API. SLF4J is a
 facade and needs to be bound to a logging framework at deployment time. Two
 underlying logging frameworks are currently supported by Bio-Formats:
 

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -2263,9 +2263,9 @@ utilityRating = Fair
 reader = RHKReader
 
 [SBIG]
-owner = `Santa Barbara Instrument Group (SBIG) <http://diffractionlimited.com/>`_
+owner = `Diffraction Limited <https://diffractionlimited.com/>`_ (formerly Santa Barbara Instrument Group)
 bsd = no
-weHave = * an `official SBIG specification document <http://diffractionlimited.com/support/sbig-archives/>`_ \n
+weHave = * an `official SBIG specification document <https://diffractionlimited.com/downloads/sbig/AppNoteArchive.zip>`_ \n
 * a few SBIG files
 weWant = * more SBIG files
 pixelsRating = Very good


### PR DESCRIPTION
Diffraction acquired SBIG and rearranged the site. SLF4J don't like HTTPS.