### PR TITLE
Ignore LOCI hyperlinks.

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -438,4 +438,5 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://libjpeg-turbo.org',
     r'https://www.biovis.com/.*', # SSLV3_ALERT_HANDSHAKE_FAILURE
     r'https://github.com/ome/.*', # 429 too many requests for url
+    'http.*/loci.wisc.edu/.*', # temporary, until they sort out eliceirilab.org
 ]


### PR DESCRIPTION
This PR reduces [BIOFORMATS-linkcheck](https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/) clutter while LOCI sort out their migration to https://eliceirilab.org/. *Do not merge,* they'll get back to us when they're sorted.