### PR TITLE
Add Olympus-lifescience to ignore due to intermittent 404

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -417,6 +417,7 @@ linkcheck_retries = int(os.environ.get("SPHINX_LINKCHECK_RETRIES", 5))
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
 linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     'https://www.olympus-global.com',
+    'https://www.olympus-lifescience.com/en/',
     'http://www.lavisionbiotec.com/',
     r'.*[.]sourceforge.net',
     r'http://www.libpng.org/.*',


### PR DESCRIPTION
Adding to ignore due to frequent failures such as:
`broken https://www.olympus-lifescience.com/en/ - 404 Client Error: Not Found for url: https://www.olympus-lifescience.com/en/`
