### PR TITLE
Temporarily add imagej.net to link check ignore list

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -437,6 +437,7 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://www.mayo.edu/.*',
     r'https://imagej.net/.*',  # Temporary due to security exploit
     r'http://imagej.net/.*',  # Temporary due to security exploit
+    r'https://valelab.ucsf.edu/.*',  # Temporary due to invalid certificate
     r'https://libjpeg-turbo.org',
     r'https://www.biovis.com/.*', # SSLV3_ALERT_HANDSHAKE_FAILURE
     r'https://github.com/ome/.*', # 429 too many requests for url

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -438,4 +438,5 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://libjpeg-turbo.org',
     r'https://www.biovis.com/.*', # SSLV3_ALERT_HANDSHAKE_FAILURE
     r'https://github.com/ome/.*', # 429 too many requests for url
+    r'https://imagej.net/.*'  # Temporary due to security exploit
 ]

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -438,5 +438,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://libjpeg-turbo.org',
     r'https://www.biovis.com/.*', # SSLV3_ALERT_HANDSHAKE_FAILURE
     r'https://github.com/ome/.*', # 429 too many requests for url
-    r'https://imagej.net/.*'  # Temporary due to security exploit
+    r'https://imagej.net/.*',  # Temporary due to security exploit
+    r'http://imagej.net/.*'  # Temporary due to security exploit
 ]

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -435,9 +435,9 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://testng.org/*', # Invalid SSL certificate
     r'http://www.bio-rad.com/*', # 503 Server Error with Sphinx v1.8.5  
     r'https://www.mayo.edu/.*',
+    r'https://imagej.net/.*',  # Temporary due to security exploit
+    r'http://imagej.net/.*',  # Temporary due to security exploit
     r'https://libjpeg-turbo.org',
     r'https://www.biovis.com/.*', # SSLV3_ALERT_HANDSHAKE_FAILURE
     r'https://github.com/ome/.*', # 429 too many requests for url
-    r'https://imagej.net/.*',  # Temporary due to security exploit
-    r'http://imagej.net/.*'  # Temporary due to security exploit
 ]


### PR DESCRIPTION
Adding imagej.net to the linkcheck ignore list until the site is fully restored. See https://forum.image.sc/t/imagej-wiki-is-down/39672 for further details