### PR TITLE
ome-common: fix javadoc.io links

### DIFF
--- a/sphinx/developers/in-memory.rst
+++ b/sphinx/developers/in-memory.rst
@@ -4,7 +4,7 @@ In-memory reading and writing in Bio-Formats
 Bio-Formats readers and writers are traditionally used to handle image files 
 from disk. However it is also possible to achieve reading and writing of files from 
 in-memory sources. This is handled by mapping the in-memory data to a file location using :common_javadoc:`Location.mapFile() 
-<loci/common/Location.html#mapFile(java.lang.String-loci.common.IRandomAccess)>`.
+<loci/common/Location.html#mapFile(java.lang.String,loci.common.IRandomAccess)>`.
 
 ::
 

--- a/sphinx/developers/in-memory.rst
+++ b/sphinx/developers/in-memory.rst
@@ -4,7 +4,7 @@ In-memory reading and writing in Bio-Formats
 Bio-Formats readers and writers are traditionally used to handle image files 
 from disk. However it is also possible to achieve reading and writing of files from 
 in-memory sources. This is handled by mapping the in-memory data to a file location using :common_javadoc:`Location.mapFile() 
-<loci/common/Location.html#mapFile-java.lang.String-loci.common.IRandomAccess->`.
+<loci/common/Location.html#mapFile(java.lang.String-loci.common.IRandomAccess)>`.
 
 ::
 

--- a/sphinx/developers/reader-guide.rst
+++ b/sphinx/developers/reader-guide.rst
@@ -144,8 +144,8 @@ Thus, a stub for ``initFile(String)`` might look like this:
 
 
 For more details, see
-:common_javadoc:`loci.common.Location.mapId(java.lang.String, java.lang.String) <loci/common/Location.html#mapId-java.lang.String-java.lang.String->`
-and :common_javadoc:`loci.common.Location.getMappedId(java.lang.String) <loci/common/Location.html#getMappedId-java.lang.String->`.
+:common_javadoc:`loci.common.Location.mapId(java.lang.String, java.lang.String) <loci/common/Location.html#mapId(java.lang.String-java.lang.String)>`
+and :common_javadoc:`loci.common.Location.getMappedId(java.lang.String) <loci/common/Location.html#getMappedId(java.lang.String)>`.
 
 Variables to populate
 ---------------------

--- a/sphinx/developers/reader-guide.rst
+++ b/sphinx/developers/reader-guide.rst
@@ -144,7 +144,7 @@ Thus, a stub for ``initFile(String)`` might look like this:
 
 
 For more details, see
-:common_javadoc:`loci.common.Location.mapId(java.lang.String, java.lang.String) <loci/common/Location.html#mapId(java.lang.String-java.lang.String)>`
+:common_javadoc:`loci.common.Location.mapId(java.lang.String, java.lang.String) <loci/common/Location.html#mapId(java.lang.String,java.lang.String)>`
 and :common_javadoc:`loci.common.Location.getMappedId(java.lang.String) <loci/common/Location.html#getMappedId(java.lang.String)>`.
 
 Variables to populate


### PR DESCRIPTION
See https://github.com/ome/bio-formats-documentation/pull/155, this updates the javadoc.io hyperlinks for the new `ome-common` release to Maven Central 

--depends-on https://github.com/ome/bioformats/pull/3593 where this component is bumped