### PR TITLE
Revert "ome-common: fix javadoc.io links"

### DIFF
--- a/sphinx/developers/in-memory.rst
+++ b/sphinx/developers/in-memory.rst
@@ -4,7 +4,7 @@ In-memory reading and writing in Bio-Formats
 Bio-Formats readers and writers are traditionally used to handle image files 
 from disk. However it is also possible to achieve reading and writing of files from 
 in-memory sources. This is handled by mapping the in-memory data to a file location using :common_javadoc:`Location.mapFile() 
-<loci/common/Location.html#mapFile(java.lang.String,loci.common.IRandomAccess)>`.
+<loci/common/Location.html#mapFile-java.lang.String-loci.common.IRandomAccess->`.
 
 ::
 

--- a/sphinx/developers/reader-guide.rst
+++ b/sphinx/developers/reader-guide.rst
@@ -144,8 +144,8 @@ Thus, a stub for ``initFile(String)`` might look like this:
 
 
 For more details, see
-:common_javadoc:`loci.common.Location.mapId(java.lang.String, java.lang.String) <loci/common/Location.html#mapId(java.lang.String,java.lang.String)>`
-and :common_javadoc:`loci.common.Location.getMappedId(java.lang.String) <loci/common/Location.html#getMappedId(java.lang.String)>`.
+:common_javadoc:`loci.common.Location.mapId(java.lang.String, java.lang.String) <loci/common/Location.html#mapId-java.lang.String-java.lang.String->`
+and :common_javadoc:`loci.common.Location.getMappedId(java.lang.String) <loci/common/Location.html#getMappedId-java.lang.String->`.
 
 Variables to populate
 ---------------------


### PR DESCRIPTION
Reverts ome/bio-formats-documentation#175

These links broke again following the release of `org.openmicroscopy.org:ome-common:6.0.6` and the bump of the component in Bio-Formats - see https://javadoc.io/static/org.openmicroscopy/ome-common/6.0.5/loci/common/Location.html#mapFile(java.lang.String,loci.common.IRandomAccess) vs https://javadoc.io/static/org.openmicroscopy/ome-common/6.0.6/loci/common/Location.html#mapFile-java.lang.String-loci.common.IRandomAccess-

The context of https://github.com/ome/bioformats/pull/3596 now clarifies the source of the formatting change. As it turns out, this is a by-product of the JDK used for compilation (JDK 14 was unwillingly used for `ome-common 6.0.5` vs JD8 previously). This PR restores the Javadoc formatting to match the JDK8-generated style.

Note that https://github.com/ome/bio-formats-documentation/pull/155 was required for the same reason as `org.openmicroscopy:ome-xml:6.1.0` was compiled with a JDK > 8.  It will probably need to be reverted with the bump to the upcoming patch release of `ome-xml`.


