### PR TITLE
Javadoc link fixes

### DIFF
--- a/sphinx/developers/file-reader.rst
+++ b/sphinx/developers/file-reader.rst
@@ -85,7 +85,7 @@ from the OME-XML Metadata. These fields can be accessed in a similar way to the 
 An example of such values would be the physical size of dimensions X, Y and Z. The accessor methods 
 for these properties return a :xml_javadoc:`Length <ome/units/quantity/Length.html>` object which 
 contains both the value and unit of the dimension. These lengths can also be converted to other units using 
-:xml_javadoc:`value(ome.units.unit.Unit) <ome/units/quantity/Length.html#value(ome.units.unit.Unit)>`
+:xml_javadoc:`value(ome.units.unit.Unit) <ome/units/quantity/Length.html#value-ome.units.unit.Unit->`
 An example of reading and converting these physical sizes values can be found in 
 :download:`ReadPhysicalSize.java <examples/ReadPhysicalSize.java>`
 

--- a/sphinx/developers/in-memory.rst
+++ b/sphinx/developers/in-memory.rst
@@ -4,7 +4,7 @@ In-memory reading and writing in Bio-Formats
 Bio-Formats readers and writers are traditionally used to handle image files 
 from disk. However it is also possible to achieve reading and writing of files from 
 in-memory sources. This is handled by mapping the in-memory data to a file location using :common_javadoc:`Location.mapFile() 
-<loci/common/Location.html#mapFile(java.lang.String,loci.common.IRandomAccess)>`.
+<loci/common/Location.html#mapFile-java.lang.String-loci.common.IRandomAccess->`.
 
 ::
 

--- a/sphinx/developers/reader-guide.rst
+++ b/sphinx/developers/reader-guide.rst
@@ -144,8 +144,8 @@ Thus, a stub for ``initFile(String)`` might look like this:
 
 
 For more details, see
-:common_javadoc:`loci.common.Location.mapId(java.lang.String, java.lang.String) <loci/common/Location.html#mapId(java.lang.String,java.lang.String)>`
-and :common_javadoc:`loci.common.Location.getMappedId(java.lang.String) <loci/common/Location.html#getMappedId(java.lang.String)>`.
+:common_javadoc:`loci.common.Location.mapId(java.lang.String, java.lang.String) <loci/common/Location.html#mapId-java.lang.String-java.lang.String->`
+and :common_javadoc:`loci.common.Location.getMappedId(java.lang.String) <loci/common/Location.html#getMappedId-java.lang.String->`.
 
 Variables to populate
 ---------------------


### PR DESCRIPTION
Reverts #175 and #155 

Recent patch releases of the `org.openmicroscopy.org:ome-common` and `org.openmicroscopy.org:ome-xml` have been compiled with JDK versions greater than 8 leading to formatting changes in the Javadoc anchor URLs. See https://javadoc.io/static/org.openmicroscopy/ome-common/6.0.5/loci/common/Location.html#mapFile(java.lang.String,loci.common.IRandomAccess) vs https://javadoc.io/static/org.openmicroscopy/ome-common/6.0.6/loci/common/Location.html#mapFile-java.lang.String-loci.common.IRandomAccess- and https://javadoc.io/static/org.openmicroscopy/ome-xml/6.1.0/ome/units/quantity/Length.html#value(ome.units.unit.Unit) vs https://javadoc.io/static/org.openmicroscopy/ome-xml/6.1.2/ome/units/quantity/Length.html#value-ome.units.unit.Unit-


With the the latest patch releases of `ome-common` and `ome-xml` compiled with JDK8, the anchors are using the old style and this PR reverts the fixes previously merged to use the JDK8 style.
