### PR TITLE
Temporary ignore https://spider.wadsworth.org

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -440,4 +440,5 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://github.com/ome/.*', # 429 too many requests for url
     # Too many redirects - see https://github.com/sphinx-doc/sphinx/pull/8131
     r'https://www.cytivalifesciences.com/en/us/.*',
+    r'https://spider.wadsworth.org/.*',
 ]


### PR DESCRIPTION
The SSL certificate expired last week. The SPIDER team has been contacted about
the update. In the meantime this should reduce the noise in the daily linkcheck
builds