### PR TITLE
Add references to the public IMS formats specification page

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -421,8 +421,9 @@ extensions = .ims
 owner = `Oxford Instruments <https://imaris.oxinst.com/>`_ (formerly Bitplane)
 bsd = no
 versions = 2.7, 3.0, 5.5
+software = `Imaris writer <https://github.com/imaris/ImarisWriter>`_
 weHave = * an Imaris (RAW) specification document (from no later than 1997 November 11, in HTML) \n
-* an Imaris 5.5 (HDF) specification document \n
+* an `Imaris 5.5 (HDF) specification document <https://imaris.oxinst.com/support/imaris-file-format>`_ \n
 * Bitplane's bfFileReaderImaris3N code (from no later than 2005, in C++) \n
 * several older Imaris (RAW) datasets \n
 * one Imaris 3 (TIFF) dataset \n


### PR DESCRIPTION
Also link to the Imaris writer as the reference implementation for writing
IMS files

Following a support thread with EU Support BitPlane (Call#120669)