### PR TITLE
Add valelab4.ucsf.edu to the exclude list

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -442,4 +442,5 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://www.cytivalifesciences.com/en/us/.*',
     r'https://spider.wadsworth.org/.*',
     r'https://wiki-bsse.ethz.ch/display.*',
+    r'https://valelab4.ucsf.edu/.*', # Invalid SSL certificate
 ]


### PR DESCRIPTION
The website is up but the SSL certificate has expired since one week