### PR TITLE
Generating-test-images: add ChannelName

### DIFF
--- a/sphinx/developers/generating-test-images.rst
+++ b/sphinx/developers/generating-test-images.rst
@@ -265,6 +265,9 @@ with their default values, is shown below.
     - * physicalSizeZ
       * real depth of the pixels, supports units defaulting to microns
       *
+    - * ChannelName_x
+      * the channel name for channel x
+      *
     - * color
       * the default color for all channels
       * null


### PR DESCRIPTION
Adding ChannelName to the generating test images page as a follow up to https://github.com/ome/bioformats/pull/3668