### PR TITLE
Ignore list: add Zeiss and NIH links due to SSL errors

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -438,6 +438,9 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://libjpeg-turbo.org',
     r'https://www.biovis.com/.*', # SSLV3_ALERT_HANDSHAKE_FAILURE
     r'https://github.com/ome/.*', # 429 too many requests for url
+    r'https://cit.nih.gov/', # Invalid SSL certificate
+    r'https://www.zeiss.com/microscopy/int/downloads/', # Invalid SSL certificate
+    r'https://portal.zeiss.com/download-center/softwares/mic/', # Invalid SSL certificate
     # Too many redirects - see https://github.com/sphinx-doc/sphinx/pull/8131
     r'https://www.cytivalifesciences.com/en/us/.*',
     r'https://spider.wadsworth.org/.*',


### PR DESCRIPTION
These 3 links have been failing for a number of days now (https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/594/consoleFull), due to `Max retries exceeded ... (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1056)')))` and `Max retries exceeded with url: / (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1056)')))`