### PR TITLE
Remove broken link to xuvtools.org

### DIFF
--- a/sphinx/users/xuvtools/index.rst
+++ b/sphinx/users/xuvtools/index.rst
@@ -1,6 +1,6 @@
 XuvTools
 ========
 
-`XuvTools <http://www.xuvtools.org>`_ is automated 3D stitching software
+`XuvTools is automated 3D stitching software
 for biomedical image data.  As of release 1.8.0, XuvTools uses
 Bio-Formats to read image data.

--- a/sphinx/users/xuvtools/index.rst
+++ b/sphinx/users/xuvtools/index.rst
@@ -1,6 +1,6 @@
 XuvTools
 ========
 
-`XuvTools is automated 3D stitching software
+XuvTools is automated 3D stitching software
 for biomedical image data.  As of release 1.8.0, XuvTools uses
 Bio-Formats to read image data.


### PR DESCRIPTION
This PR is in response to broken builds (https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/601/) which have highlighted that the http://www.xuvtools.org link appears to be no longer maintained.

@emmenlau would you perhaps know if there is a suitable alternative link we could use here? 