### PR TITLE
Add version history for v6.9.0

### DIFF
--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -16,9 +16,6 @@ New file formats:
 
 File format fixes and improvements:
 
-* Aperio SVS TIFF
-   - fixed handling of macro and label images
-
 * FEI TIFF
    - fixed parsing of physical pixel sizes for Phenom data
 

--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -31,9 +31,6 @@ File format fixes and improvements:
 * Leica LIF
    - improved parsing of channel metadata (thanks to Zach Marin)
 
-* MetaMorph Stack (STK)
-   - enable support for reading STK files from VisiView software
-
 * Nikon NIS-Elements ND2
    -improved parsing of metadata tables with invalid characters
 
@@ -41,7 +38,6 @@ File format fixes and improvements:
    - performance improvements of tile read speeds for some pyramid OME-TIFFs
 
 * PerkinElmer Operetta
-   - performance improvements for parsing large datasets (thanks to Nicolas Chiaruttini)
    - enabled support for handling sparse planes
 
 Bio-Formats improvements:

--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -8,11 +8,11 @@ New file formats:
 
 * Leica LOF
    - added support for reading Leica LOF files.
-     This functionality was implemented with thanks to Leica Microsystems
+     This functionality was implemented and contributed by Leica Microsystems
 
 * Leica XLEF
    - added support for reading Leica XLEF files.
-     This functionality was implemented with thanks to Leica Microsystems
+     This functionality was implemented and contributed by Leica Microsystems
 
 File format fixes and improvements:
 

--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -1,6 +1,62 @@
 Version history
 ===============
 
+6.9.0 (2022 February)
+---------------------
+
+New file formats:
+
+* Leica LOF
+   - added support for reading and writing Leica LOF files
+     This functionality was implemented with thanks to Leica Microsystems
+
+* Leica XLEF
+   - added support for reading and writing Leica XLEF files
+     This functionality was implemented with thanks to Leica Microsystems
+
+File format fixes and improvements:
+
+* Aperio SVS TIFF
+   - fixed handling of macro and label images
+
+* FEI TIFF
+   - fixed parsing of physical pixel sizes for Phenom data
+
+* Imspector OBF
+   - improved handling of deflate errors when opening older OBF files (thanks to Nils Gladitz)
+
+* JPEG
+   - performance improvements to reduce memory required to read tiles from large JPEGs
+
+* Leica LIF
+   - improved parsing of channel metadata (thanks to Zach Marin)
+
+* MetaMorph Stack (STK)
+   - enable support for reading STK files from VisiView software
+
+* Nikon NIS-Elements ND2
+   -improved parsing of metadata tables with invalid characters
+
+* OME-TIFF
+   - performance improvements of tile read speeds for some pyramid OME-TIFFs
+
+* PerkinElmer Operetta
+   - performance improvements for parsing large datasets (thanks to Nicolas Chiaruttini)
+   - enabled support for handling sparse planes
+
+Bio-Formats improvements:
+
+* added new API methods to FormatTools for creating well names
+* added a swap option to bfconvert to override input dimension order (thanks to Roberto Calabrese)
+
+Documentation improvements:
+
+* new public sample files for `Leica XLEF <https://downloads.openmicroscopy.org/images/Leica-XLEF/>`_ (thanks to Leica Microsystems)
+* added documentation for using the swap option with the command line tools
+* updated the process for contributing sample files via `Zenodo <https://zenodo.org/>`_
+* updated the link to NDP.view2 software on the Hamamatsu ndpi format page
+
+
 6.8.1 (2022 January)
 --------------------
 

--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -7,11 +7,11 @@ Version history
 New file formats:
 
 * Leica LOF
-   - added support for reading and writing Leica LOF files
+   - added support for reading Leica LOF files.
      This functionality was implemented with thanks to Leica Microsystems
 
 * Leica XLEF
-   - added support for reading and writing Leica XLEF files
+   - added support for reading Leica XLEF files.
      This functionality was implemented with thanks to Leica Microsystems
 
 File format fixes and improvements:


### PR DESCRIPTION
Adding the initial proposed version history section for the 6.9.0 release. The text from this PR will be the same text used on the release announcement on the OME website and community sites/mailing lists such as image.sc


The full list of PR's included will be from https://github.com/ome/bio-formats-documentation/milestone/20 and https://github.com/ome/bioformats/milestone/83?closed=1