### PR TITLE
TIFF standard: Update link

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -2406,7 +2406,7 @@ owner = `Adobe <https://www.adobe.com>`_
 developer = Aldus and Microsoft
 bsd = yes
 samples = `Big TIFF <https://www.awaresystems.be/imaging/tiff/bigtiff.html#samples>`_
-weHave = * `TIFF specification documents from Adobe <https://www.adobe.io/open/standards/TIFF.html>`_ \n
+weHave = * `TIFF specification documents from Adobe <https://www.loc.gov/preservation/digital/formats/fdd/fdd000022.shtml>`_ \n
 * a `TIFF specification document <https://www.awaresystems.be/imaging/tiff.html>`_ \n
 * `public sample images <https://downloads.openmicroscopy.org/images/TIFF/>`__\n
 * many TIFF datasets \n


### PR DESCRIPTION
Link to the TIFF standard has been broken on the adobe site for a number of days. See posts [Adobe & TIFF spec](https://community.adobe.com/t5/using-the-community-discussions/broken-link-to-open-standards-on-adobe-io/m-p/12753322) and ​​[second post](https://experienceleaguecommunities.adobe.com/t5/adobe-i-o-cloud-extensibility/broken-link-to-open-standards-on-adobe-io/td-p/441124).