### PR TITLE
Temporarily add MIPAV to link check ignore list

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -447,5 +447,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://spider.wadsworth.org/.*',
     r'https://wiki-bsse.ethz.ch/display.*',
     r'https://valelab4.ucsf.edu/.*', # Invalid SSL certificate
+    r'http://mipav.cit.nih.gov/.*',
     r'https://www.perkinelmer.com', # 500 server error
 ]


### PR DESCRIPTION
This is due to link check failures in https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/

This appears to be potentially intermittent as the link had been working again on Friday afternoon but is gone again now. I will continue to monitor it for now and either replace the link or close this PR