### PR TITLE
Update link to View5D

### DIFF
--- a/sphinx/users/imagej/index.rst
+++ b/sphinx/users/imagej/index.rst
@@ -27,7 +27,7 @@ ways:
    `Image5D <http://imagej.net/Image5D>`_ plugin
    (if installed)
 -  With Rainer Heintzmann's
-   `View5D <http://www.nanoimaging.de/View5D/>`_ plugin (if installed)
+   `View5D <https://github.com/fiji/View5D/>`_ plugin (if installed)
 
 ImageJ v1.37 and later automatically (via ``HandleExtraFileTypes``) calls
 the Bio-Formats logic, if installed, as needed when a file is opened

--- a/sphinx/users/imagej/index.rst
+++ b/sphinx/users/imagej/index.rst
@@ -27,7 +27,7 @@ ways:
    `Image5D <http://imagej.net/Image5D>`_ plugin
    (if installed)
 -  With Rainer Heintzmann's
-   `View5D <https://github.com/fiji/View5D/>`_ plugin (if installed)
+   `View5D <https://imagej.net/plugins/view5d>`_ plugin (if installed)
 
 ImageJ v1.37 and later automatically (via ``HandleExtraFileTypes``) calls
 the Bio-Formats logic, if installed, as needed when a file is opened


### PR DESCRIPTION
Update link to View5D as previous link remains broken.
The suitable options I could find were between https://github.com/fiji/View5D/ and https://github.com/RainerHeintzmann/View5D. As the content relates to users using the plugin in ImageJ I opted for the FIJI link. 