### PR TITLE
Bump logbook version in developer docs

### DIFF
--- a/sphinx/developers/java-library.rst
+++ b/sphinx/developers/java-library.rst
@@ -45,7 +45,7 @@ The complete list of third-party dependencies for `formats-gpl.jar` is as follow
     * - `Logback Classic v1.2.9 <https://logback.qos.ch>`_
       - ch.qos.logback:logback-classic:1.2.9
       - `Eclipse Public License v1.0`_
-    * - `Logback Core v1.2.9 <http://logback.qos.ch>`_
+    * - `Logback Core v1.2.9 <https://logback.qos.ch>`_
       - ch.qos.logback:logback-core:1.2.9
       - `Eclipse Public License v1.0`_
     * - `JHDF5 v19.04.0 <https://unlimited.ethz.ch/display/JHDF/>`_

--- a/sphinx/developers/java-library.rst
+++ b/sphinx/developers/java-library.rst
@@ -42,7 +42,7 @@ The complete list of third-party dependencies for `formats-gpl.jar` is as follow
     * - Package
       - Maven name
       - License
-    * - `Logback Classic v1.2.9 <http://logback.qos.ch>`_
+    * - `Logback Classic v1.2.9 <https://logback.qos.ch>`_
       - ch.qos.logback:logback-classic:1.2.9
       - `Eclipse Public License v1.0`_
     * - `Logback Core v1.2.9 <http://logback.qos.ch>`_

--- a/sphinx/developers/java-library.rst
+++ b/sphinx/developers/java-library.rst
@@ -42,11 +42,11 @@ The complete list of third-party dependencies for `formats-gpl.jar` is as follow
     * - Package
       - Maven name
       - License
-    * - `Logback Classic v1.2.0 <http://logback.qos.ch>`_
-      - ch.qos.logback:logback-classic:1.2.0
+    * - `Logback Classic v1.2.9 <http://logback.qos.ch>`_
+      - ch.qos.logback:logback-classic:1.2.9
       - `Eclipse Public License v1.0`_
-    * - `Logback Core v1.2.0 <http://logback.qos.ch>`_
-      - ch.qos.logback:logback-core:1.2.0
+    * - `Logback Core v1.2.9 <http://logback.qos.ch>`_
+      - ch.qos.logback:logback-core:1.2.9
       - `Eclipse Public License v1.0`_
     * - `JHDF5 v19.04.0 <https://unlimited.ethz.ch/display/JHDF/>`_
       - cisd:jhdf5:19.04.0


### PR DESCRIPTION
As a follow up to https://github.com/ome/bio-formats-documentation/pull/242 and matching version bumps throughout the BF stack