### PR TITLE
Update nih.gov link in mipav docs

### DIFF
--- a/sphinx/users/mipav/index.rst
+++ b/sphinx/users/mipav/index.rst
@@ -1,10 +1,10 @@
 MIPAV
 =====
 
-The `MIPAV <http://mipav.cit.nih.gov/>`_ (Medical Image Processing,
+The `MIPAV <https://mipav.cit.nih.gov/>`_ (Medical Image Processing,
 Analysis, and Visualization) application—developed at the `Center for
 Information Technology <https://cit.nih.gov/>`_ at the `National
-Institutes of Health <https://nih.gov/>`_—enables quantitative analysis
+Institutes of Health <https://www.nih.gov/>`_—enables quantitative analysis
 and visualization of medical images of numerous modalities such as PET,
 MRI, CT, or microscopy. You can use Bio-Formats as a plugin for MIPAV to
 read images in the formats it supports.


### PR DESCRIPTION
Link has been failing in link checks for a few days now: https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/860/consoleFull

The original link - https://nih.gov/
fails with:
` Max retries exceeded with url: / (Caused by ConnectTimeoutError(<urllib3.connection.HTTPSConnection object at 0x7f8e086c4d30>, 'Connection to nih.gov timed out. (connect timeout=30)'))`

The updated link however appears to have no issue - https://www.nih.gov/