### PR TITLE
Rename Vectra QPTIFF format page

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -2122,22 +2122,6 @@ Commercial applications that support this format include: \n
 .. seealso:: \n
   `PerkinElmer UltraVIEW system overview (pdf) <https://www.perkinelmer.com/lab-solutions/resources/PDFs/LST/Brochures/BRO_UltraVIEW-VoX-Product-Brochure.pdf>`_
 
-[PerkinElmer Vectra QPTIFF]
-extensions = .tif, .qptiff
-owner = `PerkinElmer <https://www.perkinelmer.com/>`_
-bsd = no
-pyramid = yes
-weHave = * a `specification document <https://downloads.openmicroscopy.org/images/Vectra-QPTIFF/perkinelmer/PKI_Image%20Format.docx>`__\n
-* `public sample images <https://downloads.openmicroscopy.org/images/Vectra-QPTIFF/>`__\n
-* several datasets
-pixelsRating = Very good
-metadataRating = Outstanding
-opennessRating = Outstanding
-presenceRating = Fair
-utilityRating = Fair
-reader = VectraReader
-notes = Support for this format was added in partnership with PerkinElmer
-
 [Portable Any Map]
 pagename = pgm
 extensions = .pbm, .pgm, .ppm
@@ -2567,6 +2551,22 @@ opennessRating = Fair
 presenceRating = Fair
 utilityRating = Fair
 reader = VarianFDFReader
+
+[Vectra QPTIFF]
+extensions = .tif, .qptiff
+owner = `Akoya Biosciences <https://www.akoyabio.com>`_, formerly owned by PerkinElmer
+bsd = no
+pyramid = yes
+weHave = * a `specification document <https://downloads.openmicroscopy.org/images/Vectra-QPTIFF/perkinelmer/PKI_Image%20Format.docx>`__\n
+* `public sample images <https://downloads.openmicroscopy.org/images/Vectra-QPTIFF/>`__\n
+* several datasets
+pixelsRating = Very good
+metadataRating = Outstanding
+opennessRating = Outstanding
+presenceRating = Fair
+utilityRating = Fair
+reader = VectraReader
+notes = Support for this format was added in partnership with PerkinElmer
 
 [Veeco AFM]
 extensions = .hdf


### PR DESCRIPTION
Renaming the Vectra QPTIFF format page following on from the discussion on https://github.com/ome/bio-formats-documentation/pull/248
The public sample docs and public spec are already under Vectra QPTIFF so shouldn't need to be updated