### PR TITLE
Add visitech.co.uk to the exclude list (invalid SSL certificate)

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -448,4 +448,5 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://wiki-bsse.ethz.ch/display.*',
     r'https://valelab4.ucsf.edu/.*', # Invalid SSL certificate
     r'https://www.perkinelmer.com', # 500 server error
+    r'http://www.visitech.co.uk/.*', # Invalid SSL certificate
 ]


### PR DESCRIPTION
The certificate expired lately and has not been fixed yet