### PR TITLE
Add pco.de to linkcheck ignore list

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -449,5 +449,5 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://valelab4.ucsf.edu/.*', # Invalid SSL certificate
     r'https://www.perkinelmer.com', # 500 server error
     r'http://www.visitech.co.uk/', # Invalid SSL certificate
-    r'http://www.rhk-tech.com', # Invalid SSL certificate
+    r'https://www.pco.de/', # Invalid SSL certificate
 ]

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -449,4 +449,5 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://valelab4.ucsf.edu/.*', # Invalid SSL certificate
     r'https://www.perkinelmer.com', # 500 server error
     r'http://www.visitech.co.uk/', # Invalid SSL certificate
+    r'http://www.rhk-tech.com', # Invalid SSL certificate
 ]


### PR DESCRIPTION
Adding to the ignore list as it has been failing with an invalid SSL error for a few days now. See https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/904/consoleFull