### PR TITLE
Update link to Allen Institute Vaa3d

### DIFF
--- a/sphinx/users/vaa3d/index.rst
+++ b/sphinx/users/vaa3d/index.rst
@@ -1,7 +1,7 @@
 Vaa3D
 =====
 
-`Vaa3D <http://www.alleninstitute.org/what-we-do/brain-science/research/products-tools/vaa3d/>`_,
+`Vaa3D <https://alleninstitute.org/what-we-do/brain-science/research/products-tools/vaa3d/>`_,
 developed by the `Peng Lab <http://home.penglab.com/>`_ at the `HHMI
 Janelia Farm Research Campus <http://www.hhmi.org/programs/biomedical-research/janelia-research-campus>`_, is a
 handy, fast, and versatile 3D/4D/5D Image Visualization & Analysis


### PR DESCRIPTION
Updating the link to Vaa3d in order to fix the broken linkcheck failures in https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/937/console

Original link: http://www.alleninstitute.org/what-we-do/brain-science/research/products-tools/vaa3d/
New working link: https://alleninstitute.org/what-we-do/brain-science/research/products-tools/vaa3d/