### PR TITLE
Add mediacy.com to link check ignore list

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -449,5 +449,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://valelab4.ucsf.edu/.*', # Invalid SSL certificate
     r'https://www.perkinelmer.com', # 500 server error
     r'http://www.visitech.co.uk/', # Invalid SSL certificate
+    r'http://www.mediacy.com/', # Invalid SSL certificate
     r'https://www.pco.de/', # Invalid SSL certificate
 ]

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -449,6 +449,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://valelab4.ucsf.edu/.*', # Invalid SSL certificate
     r'https://www.perkinelmer.com', # 500 server error
     r'http://www.visitech.co.uk/', # Invalid SSL certificate
-    r'http://www.mediacy.com/', # Invalid SSL certificate
+    r'http://www.mediacy.com/.*', # Invalid SSL certificate
     r'https://www.pco.de/', # Invalid SSL certificate
 ]


### PR DESCRIPTION
Adding http://www.mediacy.com/ to the ignore list due to repeated failures in daily linkcheck tests (https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/978/consoleFull):

```
(formats/deltavision: line   63) broken    http://www.mediacy.com/ - HTTPSConnectionPool(host='www.mediacy.com', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1123)')))

(formats/imagepro-sequence: line   28) broken    http://www.mediacy.com/imageproplus - HTTPSConnectionPool(host='www.mediacy.com', port=443): Max retries exceeded with url: /imageproplus (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1123)')))

```