### PR TITLE
Update octave link

### DIFF
--- a/sphinx/users/octave/index.rst
+++ b/sphinx/users/octave/index.rst
@@ -1,7 +1,7 @@
 GNU Octave
 ==========
 
-`GNU Octave <https:/octave.org>`_ is a high-level interpreted language,
+`GNU Octave <https://octave.org>`_ is a high-level interpreted language,
 primarily intended for numerical computations.
 Being an array programming language, it is naturally suited for image
 processing and handling of N dimensional datasets.


### PR DESCRIPTION
Linkcheck has been failing for octave.org for a while now: https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/1019/consoleFull

They had been having domain issues (https://octave.discourse.group/t/fosshost-domains-down/3477/34) but the linkcheck still fails.