### PR TITLE
Add checker framework.org to link check ignore

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -450,5 +450,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://www.perkinelmer.com', # 500 server error
     r'http://www.visitech.co.uk/', # Invalid SSL certificate
     r'http://www.mediacy.com/.*', # Invalid SSL certificate
+    r'https://checkerframework.org/.*', # Invalid SSL certificate
     r'https://www.pco.de/', # Invalid SSL certificate
 ]


### PR DESCRIPTION
The link https://checkerframework.org/ has been failing the linkcheck for a number of days now:
`(developers/java-library: line  186) broken    https://checkerframework.org/ - HTTPSConnectionPool(host='checkerframework.org', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1123)')))`

Taken from:
https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/1060/consoleFull