### PR TITLE
Add Oxford Instruments links to ignore list

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -402,5 +402,8 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'http://www.visitech.co.uk/', # Invalid SSL certificate
     r'http://www.mediacy.com/.*', # Invalid SSL certificate
     r'https://checkerframework.org/.*', # Invalid SSL certificate
+    r'http://www.bitplane.com/.*', # Invalid SSL certificate
+    r'https://andor.oxinst.com/.*', # Invalid SSL certificate
+    r'https://imaris.oxinst.com/.*', # Invalid SSL certificate
     r'https://www.pco.de/', # Invalid SSL certificate
 ]

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -405,5 +405,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'http://www.bitplane.com/.*', # Invalid SSL certificate
     r'https://andor.oxinst.com/.*', # Invalid SSL certificate
     r'https://imaris.oxinst.com/.*', # Invalid SSL certificate
+    r'https://www.oxinst.com/.*', # Invalid SSL certificate
     r'https://www.pco.de/', # Invalid SSL certificate
 ]


### PR DESCRIPTION
Adding 3 Oxford Instruments links to the ignore list due to SSL Certificate failures, hopefully just a temporary measure:

https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/1121/consoleFull