### PR TITLE
Add version support to LI-Flim format page

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -1313,6 +1313,7 @@ reader = KodakReader
 extensions = .fli
 developer = `Lambert Instruments <https://www.lambertinstruments.com>`_
 bsd = no
+versions = 1.0, 2.0
 weHave = * an LI-FLIM specification document \n
 * several example LI-FLIM datasets
 pixelsRating = Very good


### PR DESCRIPTION
As a follow up to https://github.com/ome/bioformats/pull/3936, adding version info to the format page as both version 1.0 and 2.0 are now supported