### PR TITLE
Update link for ZEISS AxioVision end of support

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -2779,7 +2779,7 @@ ZVI_Reader.class from the plugins folder. \n
 \n
 Commercial applications that support ZVI include `Bitplane Imaris <http://www.bitplane.com/>`_. \n
 \n
-As of May 2021, the proprietary ZEISS AxioVision software is classed as `End of Support <https://www.zeiss.co.uk/microscopy/local-content/2021/zeiss-axiovision-software-end-of-support.html>`_. Zeiss ZEN is the successor programme to AxioVision. \n
+As of May 2021, the proprietary ZEISS AxioVision software is classed as `End of Support <https://www.zeiss.com/microscopy/en/service-support/discontinued-products.html>`_. Zeiss ZEN is the successor programme to AxioVision. \n
 
 [Zeiss CZI]
 indexExtensions = .czi


### PR DESCRIPTION
Updating the link due to link check failures: https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/1140/consoleFull

Previously the link was to an announcement of end of support for AxioVision. The new link is to the list of discontinued products.