### PR TITLE
Link version history from main page

### DIFF
--- a/sphinx/about/index.rst
+++ b/sphinx/about/index.rst
@@ -194,10 +194,3 @@ metadata, original metadata, and OME metadata.
    bug free, but we are constantly working to improve it. We would
    greatly appreciate any and all input from users concerning missing or
    improperly converted metadata fields.
-
-.. toctree::
-    :maxdepth: 1
-    :hidden:
-
-    bug-reporting
-    whats-new

--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -1,7 +1,7 @@
 Version history
 ===============
 
-6.12.0 (2022 February)
+6.12.0 (2023 February)
 ----------------------
 
 File format fixes and improvements:

--- a/sphinx/index.rst
+++ b/sphinx/index.rst
@@ -18,6 +18,7 @@ supported by Bio-Formats.
 - :doc:`developers/index`
 - :doc:`formats/index`
 - :doc:`about/whats-new`
+- :doc:`about/bug-reporting`
 
 Bio-Formats |release| requires Java 8 or above and uses the *June 2016*
 release of the :model_doc:`OME Model <>`.
@@ -38,5 +39,5 @@ projects is in the :devs_doc:`Contributing Developer Documentation <>`.
     developers/index
     formats/index
     about/whats-new
-
+    about/bug-reporting
 

--- a/sphinx/index.rst
+++ b/sphinx/index.rst
@@ -17,6 +17,7 @@ supported by Bio-Formats.
 - :doc:`users/index`
 - :doc:`developers/index`
 - :doc:`formats/index`
+- :doc:`about/whats-new`
 
 Bio-Formats |release| requires Java 8 or above and uses the *June 2016*
 release of the :model_doc:`OME Model <>`.
@@ -36,5 +37,6 @@ projects is in the :devs_doc:`Contributing Developer Documentation <>`.
     users/index
     developers/index
     formats/index
+    about/whats-new
 
 


### PR DESCRIPTION
Include the version history page on the front page and in the main table of contents. Without this PR, `about/whats-new` is only linked from `about/index`, and isn't easily visible within that page. With this PR, the version history should be more visible, especially for anyone who doesn't already know where to find it.

In looking at this, I also noticed that the `toctree` in `about/index` results in some weird nesting in the table of contents. The version history ends up as a sub-section under `Bio-Formats metadata processing`, when I would have expected it to be its own section. This means the version history was even harder to find. I did not attempt to address this problem here as I believe it is the same as what is described in https://github.com/sphinx-doc/sphinx/issues/3007.