### PR TITLE
Add documentation for Bioconductor RBioFormats

### DIFF
--- a/sphinx/developers/index.rst
+++ b/sphinx/developers/index.rst
@@ -46,6 +46,7 @@ Using Bio-Formats as a Java library
     conversion
     matlab-dev
     python-dev
+    r-dev
     non-java-code
 
 .. seealso::

--- a/sphinx/developers/r-dev.rst
+++ b/sphinx/developers/r-dev.rst
@@ -24,3 +24,5 @@ to allow reading of proprietary microscopy image data and metadata.:
 
     # To view documentation for the version of this package installed in your system
     browseVignettes("RBioFormats")
+
+For further details and examples of how to use the package, please see the `API documentation<https://bioconductor.org/packages/devel/bioc/vignettes/RBioFormats/inst/doc/RBioFormats.html>`_ 

--- a/sphinx/developers/r-dev.rst
+++ b/sphinx/developers/r-dev.rst
@@ -1,0 +1,26 @@
+Using Bio-Formats in R
+======================
+
+OME does not currently provide an R implementation for Bio-Formats.
+However, there are options provided by the community:
+
+Bioconductor RBioFormats
+-------------------------
+
+The `RBioFormats <https://bioconductor.org/packages/devel/bioc/html/RBioFormats.html>`_ 
+project from Bioconductor provides an R package which interfaces the OME Bio-Formats Java library 
+to allow reading of proprietary microscopy image data and metadata.:
+
+.. code-block::
+
+    if (!require("BiocManager", quietly = TRUE))
+      install.packages("BiocManager")
+
+    # The following initializes usage of Bioc devel
+    BiocManager::install(version='devel')
+
+    BiocManager::install("RBioFormats")
+
+
+    # To view documentation for the version of this package installed in your system
+    browseVignettes("RBioFormats")

--- a/sphinx/developers/r-dev.rst
+++ b/sphinx/developers/r-dev.rst
@@ -25,4 +25,4 @@ to allow reading of proprietary microscopy image data and metadata.:
     # To view documentation for the version of this package installed in your system
     browseVignettes("RBioFormats")
 
-For further details and examples of how to use the package, please see the `API documentation<https://bioconductor.org/packages/devel/bioc/vignettes/RBioFormats/inst/doc/RBioFormats.html>`_ 
+For further details and examples of how to use the package, please see the `API documentation <https://bioconductor.org/packages/devel/bioc/vignettes/RBioFormats/inst/doc/RBioFormats.html>`_ 

--- a/sphinx/users/bioconductor/index.rst
+++ b/sphinx/users/bioconductor/index.rst
@@ -1,0 +1,41 @@
+Bioconductor
+============
+
+`Bioconductor`_ is a project to develop, support, and disseminate free open 
+source software that facilitates rigorous and reproducible analysis of data 
+from current and emerging biological assays. Most Bioconductor components are 
+distributed as R packages, this includes RBioFormats. RBioFormats is an R package 
+which interfaces the OME Bio-Formats Java library to allow reading of proprietary 
+microscopy image data and metadata.
+
+Installation
+------------
+
+To install this package, start R (version "4.3") and enter::
+
+    if (!require("BiocManager", quietly = TRUE))
+      install.packages("BiocManager")
+
+    # The following initializes usage of Bioc devel
+    BiocManager::install(version='devel')
+
+    BiocManager::install("RBioFormats")
+
+Documentation
+-------------
+
+To view documentation for the version of this package installed in your system, 
+start R and enter::
+
+    browseVignettes("RBioFormats")
+
+.. seealso::
+    `RBioFormats`_
+        Website for the RBioFormats package
+
+    :doc:`/developers/r-dev`
+        Section of the developer documentation describing the R wrapper
+        for Bio-Formats used by RBioFormats
+
+.. _Bioconductor: https://bioconductor.org
+.. _RBioFormats: https://bioconductor.org/packages/devel/bioc/html/RBioFormats.html

--- a/sphinx/users/index.rst
+++ b/sphinx/users/index.rst
@@ -72,6 +72,7 @@ Libraries and scripting applications
     imglib/index
     itk/index
     qu-matlab/index
+    bioconductor/index
 
 
 Numerical data processing applications

--- a/sphinx/users/index.rst
+++ b/sphinx/users/index.rst
@@ -72,7 +72,6 @@ Libraries and scripting applications
     imglib/index
     itk/index
     qu-matlab/index
-    bioconductor/index
 
 
 Numerical data processing applications
@@ -87,6 +86,7 @@ Numerical data processing applications
     knime/index
     matlab/index
     visad/index
+    r/index
 
 
 Visualization and analysis applications

--- a/sphinx/users/r/index.rst
+++ b/sphinx/users/r/index.rst
@@ -1,5 +1,11 @@
-Bioconductor
-============
+R
+=
+
+OME does not currently provide an R implementation for Bio-Formats.
+However, there are options provided by the community:
+
+Bioconductor RBioFormats
+-------------------------
 
 `Bioconductor`_ is a project to develop, support, and disseminate free open 
 source software that facilitates rigorous and reproducible analysis of data 


### PR DESCRIPTION
This is a follow up to the request raised on forum thread https://forum.image.sc/t/possible-addition-to-https-www-openmicroscopy-org-bio-formats-downloads-rbioformats/79474

This PR adds 2 new pages, adding Bioconductor to the Users list (under libraries and sciprting applications) and also a page on `Using Bio-Formats in R` under the developer section.