### PR TITLE
Re-adding nifti to linkcheck ignore list

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -382,4 +382,5 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://imaris.oxinst.com/.*', # Invalid SSL certificate
     r'https://www.oxinst.com/.*', # Invalid SSL certificate
     r'http://www.veeco.com', # Invalid SSL certificate
+    r'https://nifti.nimh.nih.gov/nifti-1/.*',
 ]


### PR DESCRIPTION
Re-adding this to the linkcheck ignore as it has been failing on and off quite frequently (https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/219/console)

Currently the http://big.umassmed.edu/ link is also broken but I will wait a few days to see if it returns before seeking a replacement