### PR TITLE
Remove notes about sorting table columns

### DIFF
--- a/src/main/java/MakeDatasetStructureTable.java
+++ b/src/main/java/MakeDatasetStructureTable.java
@@ -62,8 +62,6 @@ public class MakeDatasetStructureTable {
     out.println("choose if you want");
     out.println("to open/import a dataset in a particular format.");
     out.println();
-    out.println("You can sort this table by clicking on any of the headings.");
-    out.println();
     out.println(".. list-table::");
     out.println("   :class: sortable");
     out.println("   :header-rows: 1");

--- a/src/main/resources/templates/FormatTable.vm
+++ b/src/main/resources/templates/FormatTable.vm
@@ -3,8 +3,6 @@ Supported Formats
 
 :term:`Ratings legend and definitions`
 
-You can sort this table by clicking on any of the headings.
-
 .. list-table::
    :class: sortable
    :header-rows: 1

--- a/src/main/resources/templates/meta-summary.vm
+++ b/src/main/resources/templates/meta-summary.vm
@@ -4,8 +4,6 @@ Summary of supported metadata fields
 Format readers
 --------------
 
-You can sort this table by clicking on any of the headings.
-
 .. list-table::
    :class: sortable
    :header-rows: 1
@@ -37,8 +35,6 @@ You can sort this table by clicking on any of the headings.
 
 Metadata fields
 ---------------
-
-You can sort this table by clicking on any of the headings.
 
 .. list-table::
    :class: sortable


### PR DESCRIPTION
This feature has been broken for many years: https://trello.com/c/oNX1t6DS/245-formats-table-columns-not-sortable

A quick look through RTD documentation suggests there isn't an easy way to re-add this feature, so for now just removing the `You can sort...` statements for clarity.