### PR TITLE
Update umassmed link

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -879,7 +879,7 @@ reader = HitachiReader
 
 [I2I]
 extensions = .i2i
-developer = `Biomedical Imaging Group, UMass Medical School <http://big.umassmed.edu/>`_
+developer = `Biomedical Imaging Group, UMass Medical School <https://www.umassmed.edu/>`_
 bsd = no
 weHave = * several example datasets \n
 * a specification document \n


### PR DESCRIPTION
Updating the link for the UMass Med Biomedical Imaging Group, due to a number of failures in the linkchecker: https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/224/consoleFull

I had been trying to find a more appropriate link but could not find any working links for the Biomedical Imaging Group or the I2I format. As such I have simply used the top level site for now.