### PR TITLE
Woolz: Add notice of removal to format page

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -2723,7 +2723,10 @@ presenceRating = Poor
 utilityRating = Fair
 reader = WlzReader
 writer = WlzWriter
-notes = Support for the Woolz format will be removed from Bio-Formats 7.0.0 onwards. \n
+notes = Both the reader and the writer requires the Woolz image processing library to be installed \n 
+- see https://www.emouseatlas.org/emap/analysis_tools_resources/software/woolz.html for more details \n
+\n
+Support for the Woolz format will be removed from Bio-Formats 7.0.0 onwards. \n
 For users who wish to retain support for existing Woolz files, we recommend converting \n
 these file-sets to an actively maintained open format such as OME-TIFF. This can be \n
 achieved using the Bio-Formats :command:`bfconvert` command line tool as outlined in \n

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -2723,6 +2723,11 @@ presenceRating = Poor
 utilityRating = Fair
 reader = WlzReader
 writer = WlzWriter
+notes = Support for the Woolz format will be removed from Bio-Formats 7.0.0 onwards. \n
+For users who wish to retain support for existing Woolz files, we recommend converting \n
+these file-sets to an actively maintained open format such as OME-TIFF. This can be \n
+achieved using the Bio-Formats :command:`bfconvert` command line tool as outlined in \n
+:doc:`command line tools </users/comlinetools/conversion>` \n
 
 [Zeiss Axio CSM]
 extensions = .lms


### PR DESCRIPTION
Companion PR to https://github.com/ome/bioformats/pull/4023

Adding a note to the Woolz format page to warn of support being removed in 7.0.0. Recommends users convert existing Woolz file-sets to OME-TIFF using the command line tools.
