### PR TITLE
OME-Model - Use latest rather than version for docs link

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -167,7 +167,7 @@ extlinks = {
     'omero' : (oo_root + '/omero/%s', None),
     'secvuln': (oo_root + '/security/advisories/%s', None),
     # Documentation
-    'model_doc' : (docs_root + '/ome-model/' + ome_model_version + '/' + '%s', None),
+    'model_doc' : (docs_root + '/ome-model/latest/' + '%s', None),
     'devs_doc' : (docs_root + '/contributing/%s', None),
 
 


### PR DESCRIPTION
Currently the links to OME-Model docs have been broken for recent versions, currently the link to docs is - https://docs.openmicroscopy.org/ome-model/6.3.3/

A redirect is now in place for https://docs.openmicroscopy.org/ome-model/latest/ to point to the new readthedocs link: https://ome-model.readthedocs.io/en/stable/

This PR updates the model_doc links to always use ome-model/latest rather than a specific version. If there are cases when we want specific Bio-Formats docs versions to point to specific OME-Model docs versions, then this approach may not suit and we will have to continue using a versioned approach, likely pointing to readthedocs directly.