### PR TITLE
Set sphinx.fail_on_warnings to true

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,7 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: sphinx/conf.py
+  fail_on_warning: true
 
 # Build documentation with MkDocs
 #mkdocs:

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -686,6 +686,9 @@ mif = true
 notes = The LuraWave LWF decoder library (i.e. lwf\_jsdk2.6.jar) with \n
 license code is required to decode wavelet-compressed Flex files. \n
 \n
+Note that support for the LuraWave code is **deprecated** and will be removed \n
+in Bio-Formats 7.0.0. \n
+\n
 .. seealso::\n
   `LuraTech (developers of the proprietary LuraWave LWF compression used for Flex image planes) <https://www.luratech.com/>`_
 
@@ -1792,8 +1795,8 @@ To use it, you must be using Windows 32-bit and have `Nikon's ND2 reader plugin 
 Additionally, you will need to download :source:`LegacyND2Reader.dll \n
 <lib/LegacyND2Reader.dll?raw=true>` \n
 and place it in your ImageJ plugin folder. \n
-Note that this reader is **unmaintained** and no additional support effort \n
-will be made. \n
+\n
+Note that the legacy ND2 reader is **deprecated** and will be removed in Bio-Formats 7.0.0. \n
 
 [NRRD (Nearly Raw Raster Data)]
 pagename = nrrd
@@ -2304,6 +2307,8 @@ mp4v   MPEG-4                              -                  read & write \n
 h263   H.263                               -                  read & write \n
 ====== ================================== =================== ============ \n
 \n
+Note that the legacy QT reader/writer are **deprecated** and will be removed \n
+in Bio-Formats 7.0.0. \n
 .. seealso:: \n
     `QuickTime software overview <https://support.apple.com/quicktime>`_
 


### PR DESCRIPTION
See https://github.com/ome/bio-formats-documentation/pull/311/commits/2643cd03e1f11acdbf986210216d2c9fb670989a

The initial commit in https://github.com/ome/bio-formats-documentation/pull/311 passed the readthedocs CI builds but failed the OME Jenkins CI jobs. This is due to a difference in the the handling of warnings with OME Jenkins CI being the strictest of the two.

To reduce the confusion, this sets the appropriate readthedocs configuration `sphinx.fail_on_warning` to `true`.

This PR is built on top of 698f941a6b4ad4343b92512f3dfe3eaf2ab62d44 so the expectation is that the first build will fail. With 2643cd03e1f11acdbf986210216d2c9fb670989a the second run should be successful.