### PR TITLE
Bio-Formats 6.14.0 version history

### DIFF
--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -7,29 +7,29 @@ Deprecation warnings:
 
 * Legacy ND2 Reader
    - The LegacyND2Reader and underlying components have been marked as deprecated in preparation 
-for removal in the upcoming 7.0.0 major release of Bio-Formats. This reader depends on an outdated 
-DLL which has not been built in years, is untested and fully superseded by the new NativeND2Reader. 
-From Bio-Formats 7.0.0 onwards the existing NativeND2Reader will be renamed as ND2Reader and act as 
-the sole reader for the format. Support for the ND2 format will be unaffected and continue via this 
-newly renamed reader.
+     for removal in the upcoming 7.0.0 major release of Bio-Formats. This reader depends on an outdated 
+     DLL which has not been built in years, is untested and fully superseded by the new NativeND2Reader. 
+     From Bio-Formats 7.0.0 onwards the existing NativeND2Reader will be renamed as ND2Reader and act as 
+     the sole reader for the format. Support for the ND2 format will be unaffected and continue via this 
+     newly renamed reader
 
 * Legacy QuickTime
    - The LegacyQT Reader, Writer and Tools have been marked as deprecated in preparation for removal 
-in the upcoming 7.0.0 major release of Bio-Formats. These classes depended on the external QuickTime 
-for Java library which is long obsolete. From Bio-Formats 7.0.0 onwards the existing NativeQTReader 
-will be renamed as QTReader and support for QuickTime will limited to non legacy readers and writers.
+     in the upcoming 7.0.0 major release of Bio-Formats. These classes depended on the external QuickTime 
+     for Java library which is long obsolete. From Bio-Formats 7.0.0 onwards the existing NativeQTReader 
+     will be renamed as QTReader and support for QuickTime will limited to non legacy readers and writers.
 
 * LuraWave Codec
    - The LuraWave Codec along with the LuraWaveService and associated components have been marked as 
-deprecated in preparation for removal in the upcoming 7.0.0 major release of Bio-Formats. This codec 
-depends on a third-party proprietary library with a license code. Opera Flex is the format that is 
-most likely to be impacted by this change.
+     deprecated in preparation for removal in the upcoming 7.0.0 major release of Bio-Formats. This codec 
+     depends on a third-party proprietary library with a license code. Opera Flex is the format that is 
+     most likely to be impacted by this change.
 
 * Woolz
    - The Woolz Reader, Writer and Service have been marked as deprecated in preparation for removal 
-in the upcoming 7.0.0 major release of Bio-Formats. These classes rely on an underlying library and 
-we have limited ability to test or otherwise maintain it, and the maintenance status of the underlying 
-library is unclear.
+     in the upcoming 7.0.0 major release of Bio-Formats. These classes rely on an underlying library and 
+     we have limited ability to test or otherwise maintain it, and the maintenance status of the underlying 
+     library is unclear.
 
 File format fixes and improvements:
 
@@ -37,10 +37,6 @@ File format fixes and improvements:
    - updated CV7000 isThisType test to improve performance by skipping extended type checking
    - reader now handles the use case where wells are recorded, but all files were removed
    - fixed channel indexing in scenarios where more channels are defined than acquired
-
-* DICOM
-   - added initial support for reading and writing of dual personality DICOM-TIFF files
-   - fixed raw RGB tile reading
 
 * ICS (Image Cytometry Standard)
    - fixed an Illegal group reference exception when constructing slice label 

--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -17,7 +17,7 @@ Deprecation warnings:
    - The LegacyQT Reader, Writer and Tools have been marked as deprecated in preparation for removal 
      in the upcoming 7.0.0 major release of Bio-Formats. These classes depended on the external QuickTime 
      for Java library which is long obsolete. From Bio-Formats 7.0.0 onwards the existing NativeQTReader 
-     will be renamed as QTReader and support for QuickTime will limited to non legacy readers and writers.
+     will be renamed as QTReader and support for QuickTime will be limited to non legacy readers and writers.
 
 * LuraWave Codec
    - The LuraWave Codec along with the LuraWaveService and associated components have been marked as 

--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -1,6 +1,76 @@
 Version history
 ===============
 
+6.14.0 (2023 July)
+------------------
+Deprecation warnings:
+
+* Legacy ND2 Reader
+   - The LegacyND2Reader and underlying components have been marked as deprecated in preparation 
+for removal in the upcoming 7.0.0 major release of Bio-Formats. This reader depends on an outdated 
+DLL which has not been built in years, is untested and fully superseded by the new NativeND2Reader. 
+From Bio-Formats 7.0.0 onwards the existing NativeND2Reader will be renamed as ND2Reader and act as 
+the sole reader for the format. Support for the ND2 format will be unaffected and continue via this 
+newly renamed reader.
+
+* Legacy QuickTime
+   - The LegacyQT Reader, Writer and Tools have been marked as deprecated in preparation for removal 
+in the upcoming 7.0.0 major release of Bio-Formats. These classes depended on the external QuickTime 
+for Java library which is long obsolete. From Bio-Formats 7.0.0 onwards the existing NativeQTReader 
+will be renamed as QTReader and support for QuickTime will limited to non legacy readers and writers.
+
+* LuraWave Codec
+   - The LuraWave Codec along with the LuraWaveService and associated components have been marked as 
+deprecated in preparation for removal in the upcoming 7.0.0 major release of Bio-Formats. This codec 
+depends on a third-party proprietary library with a license code. Opera Flex is the format that is 
+most likely to be impacted by this change.
+
+* Woolz
+   - The Woolz Reader, Writer and Service have been marked as deprecated in preparation for removal 
+in the upcoming 7.0.0 major release of Bio-Formats. These classes rely on an underlying library and 
+we have limited ability to test or otherwise maintain it, and the maintenance status of the underlying 
+library is unclear.
+
+File format fixes and improvements:
+
+* CV7000/CV8000
+   - updated CV7000 isThisType test to improve performance by skipping extended type checking
+   - reader now handles the use case where wells are recorded, but all files were removed
+   - fixed channel indexing in scenarios where more channels are defined than acquired
+
+* DICOM
+   - added initial support for reading and writing of dual personality DICOM-TIFF files
+   - fixed raw RGB tile reading
+
+* ICS (Image Cytometry Standard)
+   - fixed an Illegal group reference exception when constructing slice label 
+
+* KLB (Keller Lab Block)
+   - fixed a bug with the reading of image planes in Z stacks
+
+* MicroManager
+   - updated handling of truncated files to prevent possible infinite loop and throw an exception
+
+Bio-Formats improvements:
+
+* updated handling of exceptions in Bio-Formats plugins to ensure readers are closed
+* updated list of external readers to include new external 
+  `ZeissQuickStartCZIReader <https://github.com/BIOP/quick-start-czi-reader>`_ (thanks to Nicolas Chiaruttini)
+* updated top-level Git mailmap to normalize commit author variants
+* added a new bf-unconfigured tool to the Bio-Formats toolbox. The new tool lists classes which 
+  are not configured for testing as part of format reader tests
+* replaced use tt tag in java docs with code tag
+
+Documentation improvements:
+
+* fixed a number of broken links
+* migrated OME-Model documentation to Read the Docs
+* added deprecation warnings to format pages of the affected components
+
+Component updates:
+
+* `ome-common` was upgraded to 6.0.17
+
 6.13.0 (2023 April)
 -------------------
 File format fixes and improvements:

--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -27,9 +27,8 @@ Deprecation warnings:
 
 * Woolz
    - The Woolz Reader, Writer and Service have been marked as deprecated in preparation for removal 
-     in the upcoming 7.0.0 major release of Bio-Formats. These classes rely on an underlying library and 
-     we have limited ability to test or otherwise maintain it, and the maintenance status of the underlying 
-     library is unclear.
+     in the upcoming 7.0.0 major release of Bio-Formats. The reader and writer are untested and rely on 
+     an underlying library which maintenance status is unclear
 
 File format fixes and improvements:
 

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -167,7 +167,7 @@ extlinks = {
     'omero' : (oo_root + '/omero/%s', None),
     'secvuln': (oo_root + '/security/advisories/%s', None),
     # Documentation
-    'model_doc' : (docs_root + '/ome-model/' + ome_model_version + '/' + '%s', None),
+    'model_doc' : (docs_root + '/ome-model/latest/' + '%s', None),
     'devs_doc' : (docs_root + '/contributing/%s', None),
 
 


### PR DESCRIPTION
Adding the initial draft of the version history, see https://github.com/ome/bioformats/milestone/94?closed=1 for the full list of what is included.