### PR TITLE
Revert: OME-Model - Use latest rather than version for docs link

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -167,7 +167,7 @@ extlinks = {
     'omero' : (oo_root + '/omero/%s', None),
     'secvuln': (oo_root + '/security/advisories/%s', None),
     # Documentation
-    'model_doc' : (docs_root + '/ome-model/latest/' + '%s', None),
+    'model_doc' : (docs_root + '/ome-model/' + ome_model_version + '/' + '%s', None),
     'devs_doc' : (docs_root + '/contributing/%s', None),
 
 


### PR DESCRIPTION
Accidentally merged a commit from https://github.com/ome/bio-formats-documentation/pull/310
Reverting back to the original state