### PR TITLE
Add luratech.com to lincheck ignore list

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -385,4 +385,5 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'http://logback.qos.ch/.*',
     r'http://www.slf4j.org/.*',
     r'https://valelab.ucsf.edu/.*',
+    r'https://www.luratech.com', # Invalid SSL certificate
 ]


### PR DESCRIPTION
Adding to the ignore list after failing linkcheck for a number of days with an SSL error, https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/246/consoleFull

`(formats/evotecperkinelmer-opera-flex: line   58) broken    https://www.luratech.com/ - HTTPSConnectionPool(host='www.luratech.com', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1123)')))`