### PR TITLE
Remove references to LuraWave

### DIFF
--- a/sphinx/developers/components.rst
+++ b/sphinx/developers/components.rst
@@ -258,7 +258,7 @@ OME-XML files in each of the released schema versions.
 
 `Stubs <https://github.com/ome/ome-stubs/tree/master>`__:
 
-Luratech LuraWave stubs and MIPAV stubs.
+MIPAV stubs.
 
 This component provides empty classes that mirror third-party dependencies
 which are required at compile time but cannot be included in the build system

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -675,7 +675,6 @@ developer = Evotec Technologies, now `PerkinElmer <https://www.perkinelmer.com/>
 bsd = no
 weHave = * many Flex datasets\n
 * `public sample images <https://downloads.openmicroscopy.org/images/Flex/>`__
-weWant = * a freely redistributable LuraWave LWF decoder
 pixelsRating = Outstanding
 metadataRating = Outstanding
 opennessRating = Poor
@@ -683,14 +682,6 @@ presenceRating = Poor
 utilityRating = Poor
 reader = FlexReader
 mif = true
-notes = The LuraWave LWF decoder library (i.e. lwf\_jsdk2.6.jar) with \n
-license code is required to decode wavelet-compressed Flex files. \n
-\n
-Note that support for the LuraWave code is **deprecated** and will be removed \n
-in Bio-Formats 7.0.0. \n
-\n
-.. seealso::\n
-  `LuraTech (developers of the proprietary LuraWave LWF compression used for Flex image planes) <https://www.luratech.com/>`_
 
 [FEI TIFF]
 extensions = .tiff


### PR DESCRIPTION
This is a companion PR to https://github.com/ome/bioformats/pull/4040

We may also want to update https://github.com/ome/ome-stubs to remove the LuraWave stubs