### PR TITLE
Add adobe.com to linkcheck ignore list

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -385,4 +385,5 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'http://logback.qos.ch/.*',
     r'http://www.slf4j.org/.*',
     r'https://valelab.ucsf.edu/.*',
+    r'https://www.adobe.com/.*',
 ]

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -385,5 +385,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'http://logback.qos.ch/.*',
     r'http://www.slf4j.org/.*',
     r'https://valelab.ucsf.edu/.*',
-    r'https://www.adobe.com/.*',
+    r'https://www.adobe.com*',
+
 ]


### PR DESCRIPTION
Adding to the ignore list for now as it has been failing the linkcheck in recent days:
https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/263/consoleFull