### PR TITLE
Bumping BF version to 7.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,9 @@
   </licenses>
 
   <properties>
-    <ome-common.version>6.0.17</ome-common.version>
+    <ome-common.version>6.0.19</ome-common.version>
     <ome-model.version>6.3.3</ome-model.version>
-    <bioformats.version>6.14.0</bioformats.version>
+    <bioformats.version>7.0.0</bioformats.version>
     <formats-gpl.version>${bioformats.version}</formats-gpl.version>
     <formats-bsd.version>${bioformats.version}</formats-bsd.version>
     <formats-api.version>${bioformats.version}</formats-api.version>


### PR DESCRIPTION
Bumping the Bio-Formats and ome-common version prior to release

Checking that the dataset table and metadata pages are correct with the removal of the readers in BF 7.0.0
