### PR TITLE
Update link to QuickTime file format

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -2248,7 +2248,7 @@ extensions = .mov
 owner = `Apple Computer <https://www.apple.com/>`_
 bsd = yes
 software = `QuickTime Player <https://support.apple.com/downloads/quicktime>`_
-weHave = * a `QuickTime specification document <https://developer.apple.com/library/content/documentation/QuickTime/QTFF/QTFFPreface/qtffPreface.html#//apple_ref/doc/uid/TP40000939>`_ \n
+weHave = * a `QuickTime specification document <https://developer.apple.com/documentation/quicktime-file-format#//apple_ref/doc/uid/TP40000939>`_ \n
 * several QuickTime datasets \n
 * the ability to produce more datasets
 weWant = * more QuickTime datasets, including: \n

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -2248,7 +2248,7 @@ extensions = .mov
 owner = `Apple Computer <https://www.apple.com/>`_
 bsd = yes
 software = `QuickTime Player <https://support.apple.com/downloads/quicktime>`_
-weHave = * a `QuickTime specification document <https://developer.apple.com/documentation/quicktime-file-format#//apple_ref/doc/uid/TP40000939>`_ \n
+weHave = * a `QuickTime specification document <https://developer.apple.com/documentation/quicktime-file-format>`_ \n
 * several QuickTime datasets \n
 * the ability to produce more datasets
 weWant = * more QuickTime datasets, including: \n


### PR DESCRIPTION
Updating the link for the QuickTime format due to failures in nightly linkcheck tests (https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/306/consoleFull)


New link is https://developer.apple.com/documentation/quicktime-file-format#//apple_ref/doc/uid/TP40000939