### PR TITLE
Update links to Zeiss main page

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -398,7 +398,7 @@ notes = * `Bio-Rad Gel Format (1sc) specification <http://biorad1sc-doc.readthed
 
 [Bio-Rad PIC]
 extensions = .pic, .raw, .xml
-owner = `ZEISS International <https://www.zeiss.com/corporate/int/home.html>`_
+owner = `ZEISS International <https://www.zeiss.com>`_
 developer = Bio-Rad
 bsd = no
 software = `Bio-Rad PIC reader plugin for ImageJ <https://imagej.nih.gov/ij/plugins/biorad.html>`_
@@ -1454,7 +1454,7 @@ mif = true
 
 [LEO]
 extensions = .sxm, .tif, .tiff
-owner = `ZEISS International <https://www.zeiss.com/corporate/int/home.html>`_
+owner = `ZEISS International <https://www.zeiss.com>`_
 bsd = no
 weHave = * Pascal code that can read LEO files (from ImageSXM) \n
 * a few LEO files\n
@@ -2684,8 +2684,8 @@ notes = Compressed BMP files are currently not supported. \n
 
 [Zeiss Axio CSM]
 extensions = .lms
-owner = `ZEISS International <https://www.zeiss.com/corporate/int/home.html>`_
-developer = `ZEISS International <https://www.zeiss.com/corporate/int/home.html>`_
+owner = `ZEISS International <https://www.zeiss.com>`_
+developer = `ZEISS International <https://www.zeiss.com>`_
 bsd = no
 weHave = * one example dataset
 pixelsRating = Good
@@ -2700,8 +2700,8 @@ the only one which saves files in the .lms format. \n
 
 [Zeiss AxioVision TIFF]
 extensions = .xml, .tif
-owner = `ZEISS International <https://www.zeiss.com/corporate/int/home.html>`_
-developer = `ZEISS International <https://www.zeiss.com/corporate/int/home.html>`_
+owner = `ZEISS International <https://www.zeiss.com>`_
+developer = `ZEISS International <https://www.zeiss.com>`_
 bsd = no
 software = `Zeiss ZEN Lite <https://www.zeiss.com/microscopy/int/products/microscope-software/zen-lite.html>`_
 weHave = * many example datasets
@@ -2717,7 +2717,7 @@ mif = true
 [Zeiss AxioVision ZVI (Zeiss Vision Image)]
 pagename = zeiss-axiovision-zvi
 extensions = .zvi
-owner = `ZEISS International <https://www.zeiss.com/corporate/int/home.html>`_
+owner = `ZEISS International <https://www.zeiss.com>`_
 developer = `Carl Zeiss Microscopy GmbH <https://www.zeiss.com/microscopy>`_
 bsd = no
 versions = 1.0, 2.0
@@ -2748,7 +2748,7 @@ As of May 2021, the proprietary ZEISS AxioVision software is classed as `End of 
 [Zeiss CZI]
 indexExtensions = .czi
 extensions = `.czi <https://www.zeiss.com/microscopy/int/products/microscope-software/zen/czi.html>`_
-developer = `ZEISS International <https://www.zeiss.com/corporate/int/home.html>`_
+developer = `ZEISS International <https://www.zeiss.com>`_
 bsd = no
 software = `Zeiss ZEN <https://www.zeiss.com/microscopy/int/products/microscope-software/zen.html>`_ \n
 `libCZI <https://github.com/zeiss-microscopy/libCZI>`_
@@ -2774,7 +2774,7 @@ notes = JPEG-XR compressed CZI files are supported on the following 64-bit platf
 [Zeiss LSM (Laser Scanning Microscope) 510/710]
 pagename = zeiss-lsm
 extensions = .lsm, .mdb
-owner = `ZEISS International <https://www.zeiss.com/corporate/int/home.html>`_
+owner = `ZEISS International <https://www.zeiss.com>`_
 bsd = no
 software = `Zeiss LSM Image Browser <https://www.zeiss.com/microscopy/int/downloads/>`_ \n
 `LSM Toolbox plugin for ImageJ <https://imagej.net/LSM_Toolbox>`_ \n


### PR DESCRIPTION
Updating the main Zeiss links due to link check failure in nightly build: https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/331/consoleFull