### PR TITLE
Update NIFTI links

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -1720,8 +1720,7 @@ notes = .. seealso:: \n
 extensions = .img, .hdr, .nii, .nii.gz
 developer = `National Institutes of Health <https://www.nih.gov/>`_
 bsd = no
-samples = `Official test data <https://nifti.nimh.nih.gov/nifti-1/data/>`_
-weHave = * `NIfTI specification documents <https://nifti.nimh.nih.gov/nifti-1/>`_\n
+weHave = * `NIfTI specification documents <https://www.nitrc.org/docman/view.php/26/204/TheNIfTI>`_\n
 * several NIfTI datasets \n
 * `public sample images <https://downloads.openmicroscopy.org/images/NIfTI/>`__
 pixelsRating = Very good


### PR DESCRIPTION
The NIFTI links have been broken in the linkcheck tests for a while now:https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/lastBuild/consoleFull
https://nifti.nimh.nih.gov/pub/dist/src/niftilib/nifti1.h had been working yesterday but testing it again today and it also seems to be down


Fixes https://github.com/ome/bio-formats-documentation/issues/336