### PR TITLE
Add sphinx-rtd-theme dependency to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,3 +2,4 @@ channels:
   - conda-forge
 dependencies:
   - maven
+  - sphinx-rtd-theme


### PR DESCRIPTION
Recent PR's have seen builds fail due to:
```
Theme error:
no theme named 'sphinx_rtd_theme' found (missing theme.conf?)
```

In the last successful builds the sphinx_rtd_theme can be seen in the dependencies and should have been installed via the requirements file.
```
channels:
- conda-forge
dependencies:
- maven
- pip:
  - recommonmark
  - readthedocs-sphinx-ext
- mock
- pillow
- sphinx
- sphinx_rtd_theme
```

In the recent failures it is missing (though sphinx does seem to be included) As far as I can tell there haven't been any changes since the previously successful builds:
```
channels:
- conda-forge
dependencies:
- maven
- pip:
  - readthedocs-sphinx-ext
- sphinx
```
