### PR TITLE
Update link to Zeiss downloads

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -2021,7 +2021,7 @@ opennessRating = Fair
 presenceRating = Poor
 utilityRating = Fair
 reader = PCXReader
-notes = Commercial applications that support PCX include `Zeiss LSM Image Browser <https://www.zeiss.com/microscopy/int/downloads/>`_.
+notes = Commercial applications that support PCX include `Zeiss LSM Image Browser <https://www.zeiss.com/microscopy/en/service-support/downloads.html>`_.
 
 [PCORAW]
 extensions = .pcoraw, .rec
@@ -2775,7 +2775,7 @@ pagename = zeiss-lsm
 extensions = .lsm, .mdb
 owner = `ZEISS International <https://www.zeiss.com>`_
 bsd = no
-software = `Zeiss LSM Image Browser <https://www.zeiss.com/microscopy/int/downloads/>`_ \n
+software = `Zeiss LSM Image Browser <https://www.zeiss.com/microscopy/en/service-support/downloads.html>`_ \n
 `LSM Toolbox plugin for ImageJ <https://imagej.net/LSM_Toolbox>`_ \n
 `LSM Reader plugin for ImageJ <https://imagej.nih.gov/ij/plugins/lsm-reader.html>`_ \n
 `DIMIN <http://www.dimin.net/>`_

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -2702,7 +2702,7 @@ extensions = .xml, .tif
 owner = `ZEISS International <https://www.zeiss.com>`_
 developer = `ZEISS International <https://www.zeiss.com>`_
 bsd = no
-software = `Zeiss ZEN Lite <https://www.zeiss.com/microscopy/int/products/microscope-software/zen-lite.html>`_
+software = `Zeiss ZEN Lite <https://www.zeiss.com/microscopy/en/products/software/zeiss-zen-lite.html>`_
 weHave = * many example datasets
 weWant = * an official specification document
 pixelsRating = Very good
@@ -2746,10 +2746,10 @@ As of May 2021, the proprietary ZEISS AxioVision software is classed as `End of 
 
 [Zeiss CZI]
 indexExtensions = .czi
-extensions = `.czi <https://www.zeiss.com/microscopy/int/products/microscope-software/zen/czi.html>`_
+extensions = `.czi <https://www.zeiss.com/microscopy/en/products/software/zeiss-zen/czi-image-file-format.html>`_
 developer = `ZEISS International <https://www.zeiss.com>`_
 bsd = no
-software = `Zeiss ZEN <https://www.zeiss.com/microscopy/int/products/microscope-software/zen.html>`_ \n
+software = `Zeiss ZEN <https://www.zeiss.com/microscopy/en/products/software/zeiss-zen.html>`_ \n
 `libCZI <https://github.com/zeiss-microscopy/libCZI>`_
 weHave = * many example datasets \n
 * `public sample images <https://downloads.openmicroscopy.org/images/Zeiss-CZI/>`__


### PR DESCRIPTION
Updating the link to the Zeiss downloads page due to linkcheck failures for the previous link: https://www.zeiss.com/microscopy/int/downloads/

The new link I am using is https://www.zeiss.com/microscopy/en/service-support/downloads.html