### PR TITLE
Add bio3d to link check ignore

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -384,4 +384,5 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://www.knime.com/community/image-processing', # https://www.knime.com/ is OK
     r'https://valelab4.ucsf.edu/.*', # Invalid SSL certificate
     r'http://www.xuvtools.org*', # Invalid SSL certificate
+    r'https://bio3d.colorado.edu*', # Invalid SSL certificate
 ]


### PR DESCRIPTION
Temporarily adding to linkcheck ignore as it has been failing in recent days due to:
```
(     formats/mrc: line   61) broken    https://bio3d.colorado.edu/imod/doc/mrc_format.txt - HTTPSConnectionPool(host='bio3d.colorado.edu', port=443): Max retries exceeded with url: /imod/doc/mrc_format.txt (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1123)')))
```

https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/372/consoleFull