### PR TITLE
Add link to Bioformats.NET6

### DIFF
--- a/sphinx/developers/dotnet-dev.rst
+++ b/sphinx/developers/dotnet-dev.rst
@@ -1,0 +1,29 @@
+Using Bio-Formats in .NET
+=========================
+
+OME does not currently provide a .NET implementation for Bio-Formats.
+However, there are options you can use to read images from .NET via Bio-Formats:
+
+Bioformats.NET6
+---------------
+
+The `Bioformats.NET6 <https://github.com/BiologyTools/BioFormatsNET6>`_ project provides Bio-Formats libraries converted to DLL, built with IKVM 8.7.1 Maven SDK for .NET6. To install add the below to your project file.:
+
+.. parsed-literal::
+
+    <PropertyGroup>
+      <MavenAdditionalRepositories>ome=https://artifacts.openmicroscopy.org/artifactory/maven/;edu.ucar=https://maven.scijava.org/content/repositories/public/;</MavenAdditionalRepositories>
+    </PropertyGroup> 
+    <ItemGroup>
+        <MavenReference Include="bioformats_package">
+          <GroupId>ome</GroupId>
+          <ArtifactId>bioformats_package</ArtifactId>
+          <Version> |release| </Version>
+        </MavenReference>
+        <MavenReference Include="cdm-core">
+          <GroupId>edu.ucar</GroupId>
+          <ArtifactId>cdm-core</ArtifactId>
+          <Version>5.3.3</Version>
+        </MavenReference>
+    </ItemGroup>
+

--- a/sphinx/developers/dotnet-dev.rst
+++ b/sphinx/developers/dotnet-dev.rst
@@ -7,7 +7,7 @@ However, there are options you can use to read images from .NET via Bio-Formats:
 Bioformats.NET6
 ---------------
 
-The `Bioformats.NET6 <https://github.com/BiologyTools/BioFormatsNET6>`_ project provides Bio-Formats libraries converted to DLL, built with IKVM 8.7.1 Maven SDK for .NET6. To install add the below to your project file.:
+The `Bioformats.NET6 <https://github.com/BiologyTools/BioFormatsNET6>`_ project provides Bio-Formats libraries converted to DLL, built with IKVM 8.7.1 Maven SDK for .NET6. To install add the below to your project file. Note that due to formatting the release version has extra whitespace surrounding it that can be removed :
 
 .. parsed-literal::
 

--- a/sphinx/developers/index.rst
+++ b/sphinx/developers/index.rst
@@ -47,6 +47,7 @@ Using Bio-Formats as a Java library
     matlab-dev
     python-dev
     r-dev
+    dotnet-dev
     non-java-code
 
 .. seealso::


### PR DESCRIPTION
Adding a new link to the Bioformats.NET6 project (https://github.com/BiologyTools/BioFormatsNET6) for users who wish to use Bio-Formats in a .NET environment.