### PR TITLE
Adding checkerframework.org to link check ignore

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -385,4 +385,5 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://valelab4.ucsf.edu/.*', # Invalid SSL certificate
     r'http://www.xuvtools.org*', # Invalid SSL certificate
     r'https://bio3d.colorado.edu*', # Invalid SSL certificate
+    r'https://checkerframework.org*', # Invalid SSL certificate
 ]


### PR DESCRIPTION
Adding checkerframework.org to the ignore list due to failures in recent nightly builds:

https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/397/consoleFull
```
(developers/java-library: line  182) broken    https://checkerframework.org/ - HTTPSConnectionPool(host='checkerframework.org', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1123)')))
```