### PR TITLE
Update link for Resource_fork Mac

### DIFF
--- a/sphinx/about/bug-reporting.rst
+++ b/sphinx/about/bug-reporting.rst
@@ -35,7 +35,7 @@ Common issues to check
 -  If the file is very, very small (4096 bytes) and any exception is
    generated when reading the file, then make sure it is not a `Mac OS
    X resource
-   fork <https://en.wikipedia.org/wiki/Resource_fork#The_Macintosh_file_system>`_.
+   fork <https://en.wikipedia.org/wiki/Resource_fork#Macintosh_file_systems>`_.
    The 'file' command should tell you:
 
    ::

--- a/sphinx/about/bug-reporting.rst
+++ b/sphinx/about/bug-reporting.rst
@@ -35,7 +35,7 @@ Common issues to check
 -  If the file is very, very small (4096 bytes) and any exception is
    generated when reading the file, then make sure it is not a `Mac OS
    X resource
-   fork <https://en.wikipedia.org/wiki/Resource_fork#Macintosh_file_systems>`_.
+   fork <https://en.wikipedia.org/wiki/Resource_fork>`_.
    The 'file' command should tell you:
 
    ::


### PR DESCRIPTION
Fixing a broken link anchor discovered via the linkchecker - https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/465/consoleFull