### PR TITLE
Add Mayo link to ignore list

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -385,4 +385,5 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://valelab4.ucsf.edu/.*', # Invalid SSL certificate
     r'http://www.xuvtools.org*', # Invalid SSL certificate
     r'https://bio3d.colorado.edu*', # Invalid SSL certificate
+    r'https://www.mayo.edu/research/core-resources/biomedical-imaging-resource-core/overview' # 403 Client Error: Forbidden
 ]


### PR DESCRIPTION
Adding link (https://www.mayo.edu/research/core-resources/biomedical-imaging-resource-core/overview) to the ignore list as it has been failing the linkcheck build for a number of days now. The link itself still looks correct and is working.

https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/469/consoleFull