### PR TITLE
Update link for Java indent style

### DIFF
--- a/sphinx/developers/code-formatting.rst
+++ b/sphinx/developers/code-formatting.rst
@@ -20,7 +20,7 @@ All Java code is formatted with:
 
 - an indentation size of two spaces
 - braces use the `Java variant of K&R style
-  <https://en.wikipedia.org/wiki/Indent_style#Variant:_Java>`__
+  <https://en.wikipedia.org/wiki/Indentation_style#Java>`__
 
 XML
 ---


### PR DESCRIPTION
Update link which has changed. Picked up by link check failure in https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/19/consoleFull