### PR TITLE
Remove link to barre.dev samples

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -612,7 +612,6 @@ samples = `David Clunie's list of DICOM image samples <https://www.dclunie.com/m
 `Whole Slide Images from DICOM Working Group 26 <ftp://medical.nema.org/medical/dicom/DataSets/WG26/>`_ \n
 `NCI Imaging Data Commons Portal <https://portal.imaging.datacommons.cancer.gov/>`_, `download instructions <https://learn.canceridc.dev/data/downloading-data>`_ \n
 `Converted Whole Slide Images <https://wsi.orthanc-server.com/orthanc/app/explorer.html>`_ \n
-`Medical Image Samples from Sebastien Barre's Medical Imaging page <https://barre.dev/medical/samples>`_ \n
 `DICOM sample image sets from OsiriX web site <http://www.osirix-viewer.com/resources/dicom-image-library/>`_
 weHave = * `DICOM specification documents <https://www.dicomstandard.org/current/>`_ \n
 * numerous DICOM datasets (see above)\n


### PR DESCRIPTION
Temporarily removing the link to Sebastien Barre's DICOM samples as the entire site has been down for a number of days now: https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/82/consoleFull

I haven't been able to find a suitable alternative link for these samples. I will monitor to see if the site returns, if so then we can close this PR 