### PR TITLE
Update 7.3.1 note on warnings to clarify potential broader impact

### DIFF
--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -21,6 +21,13 @@ File format fixes and improvements:
 Bio-Formats improvements:
 
 * fixed warnings across all components for Java 9+ 
+    - Among other things, this includes changes to how double values are parsed from strings in many format readers.
+      These changes are expected to be more lenient in allowing datasets with certain missing or invalid metadata
+      values (e.g. objective magnifications, detector voltages) to be read without throwing an exception. This means
+      that some datasets which failed to read in 7.3.0 may now suddenly work (or fail at a later point) with 7.3.1,
+      without an intentional targetted fix for that format. For specific changes to format readers, please see:
+          * https://github.com/ome/bioformats/pull/4182
+          * https://github.com/ome/bioformats/pull/4177
 * fixed a number of String comparisons
 
 Documentation improvements:

--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -25,9 +25,8 @@ Bio-Formats improvements:
       These changes are expected to be more lenient in allowing datasets with certain missing or invalid metadata
       values (e.g. objective magnifications, detector voltages) to be read without throwing an exception. This means
       that some datasets which failed to read in 7.3.0 may now suddenly work (or fail at a later point) with 7.3.1,
-      without an intentional targetted fix for that format. For specific changes to format readers, please see:
-        - https://github.com/ome/bioformats/pull/4182
-        - https://github.com/ome/bioformats/pull/4177
+      without an intentional targetted fix for that format. For specific changes to format readers, please see
+      https://github.com/ome/bioformats/pull/4182 and https://github.com/ome/bioformats/pull/4177.
 * fixed a number of String comparisons
 
 Documentation improvements:

--- a/sphinx/about/whats-new.rst
+++ b/sphinx/about/whats-new.rst
@@ -26,8 +26,8 @@ Bio-Formats improvements:
       values (e.g. objective magnifications, detector voltages) to be read without throwing an exception. This means
       that some datasets which failed to read in 7.3.0 may now suddenly work (or fail at a later point) with 7.3.1,
       without an intentional targetted fix for that format. For specific changes to format readers, please see:
-          * https://github.com/ome/bioformats/pull/4182
-          * https://github.com/ome/bioformats/pull/4177
+        - https://github.com/ome/bioformats/pull/4182
+        - https://github.com/ome/bioformats/pull/4177
 * fixed a number of String comparisons
 
 Documentation improvements:


### PR DESCRIPTION
Following today's OME meeting and separate discussion with @chris-allan, this change updates the release notes in an attempt to clarify the potential impact of using `DataTools.parseDouble` as part of the warnings cleanup in https://github.com/ome/bioformats/pull/4182 and https://github.com/ome/bioformats/pull/4177.