### PR TITLE
Update precompressed tile documentation

### DIFF
--- a/sphinx/formats/index.rst
+++ b/sphinx/formats/index.rst
@@ -31,4 +31,5 @@ available from our `sample image downloads site <http://downloads.openmicroscopy
     /supported-formats
     /metadata-summary
     pattern-file
+    precompressed
     options

--- a/sphinx/formats/precompressed.rst
+++ b/sphinx/formats/precompressed.rst
@@ -1,0 +1,34 @@
+Support for "precompressed" tiles
+=================================
+
+Some formats allow reading and/or writing "precompressed" tiles.
+This feature is primarily intended for whole slide images, each of which may have thousands of tiles.
+Data representing these tiles may be compressed, either lossily or losslessly, depending on the
+file format, imaging modality, or acquisition configuration.
+
+When reading, this allows for retrieving compressed bytes that are as close as possible
+to what is actually stored in the file. Decompression (if necessary) is the responsibility
+of the consumer.
+
+When writing, compressed bytes instead of raw bytes can be provided to the writer,
+such that the writer will just save the provided compressed bytes instead of recompressing.
+
+See also :doc:`how to work with precompressed tiles in bfconvert </users/comlinetools/precompressed>`
+
+.. _precompressed#readers:
+
+Formats that support precompressed tile reading
+-----------------------------------------------
+
+* SVS (since 7.1.0)
+* NDPI (forthcoming: https://github.com/ome/bioformats/pull/4181)
+* DICOM (forthcoming: https://github.com/ome/bioformats/pull/4190)
+
+.. _precompressed#writers:
+
+Formats that support precompressed tile writing
+-----------------------------------------------
+
+* DICOM (since 7.1.0)
+* TIFF (forthcoming: https://github.com/ome/bioformats/pull/4190)
+* OME-TIFF (forthcoming: https://github.com/ome/bioformats/pull/4190)

--- a/sphinx/formats/precompressed.rst
+++ b/sphinx/formats/precompressed.rst
@@ -21,8 +21,8 @@ Formats that support precompressed tile reading
 -----------------------------------------------
 
 * SVS (since 7.1.0)
-* NDPI (forthcoming: https://github.com/ome/bioformats/pull/4181)
-* DICOM (forthcoming: https://github.com/ome/bioformats/pull/4190)
+* NDPI (since 8.0.0)
+* DICOM (since 8.0.0)
 
 .. _precompressed#writers:
 
@@ -30,5 +30,5 @@ Formats that support precompressed tile writing
 -----------------------------------------------
 
 * DICOM (since 7.1.0)
-* TIFF (forthcoming: https://github.com/ome/bioformats/pull/4190)
-* OME-TIFF (forthcoming: https://github.com/ome/bioformats/pull/4190)
+* TIFF (since 8.0.0)
+* OME-TIFF (since 8.0.0)

--- a/sphinx/users/comlinetools/conversion.rst
+++ b/sphinx/users/comlinetools/conversion.rst
@@ -301,9 +301,11 @@ correctly. So in Windows, the above example would read::
 
     .. code-block::
         
-        bfconvert -noflat -precompressed -compression JPEG CMU-1.svs CMU-1.dcm
+        bfconvert -noflat -precompressed CMU-1.svs CMU-1.dcm
 
     .. versionadded:: 7.1.0
+
+    .. seealso:: :doc:`Summary of the precompressed tiles feature <precompressed>`
 
 .. option:: -extra-metadata METADATA FILE
 

--- a/sphinx/users/comlinetools/precompressed.rst
+++ b/sphinx/users/comlinetools/precompressed.rst
@@ -12,6 +12,11 @@ When writing, compressed bytes instead of raw bytes can be provided to the write
 such that the writer will just save the provided compressed bytes instead of recompressing.
 
 This feature is primarily exposed in the :program:`bfconvert` command, using the :option:`-precompressed` option.
+When the :option:`-precompressed` option is used, best results are obtained by:
+
+* using the :option:`-noflat` option
+* _not_ using the :option:`-compression` option (this can work, but may force tile recompression)
+* _not_ using the :option:`-tilex` or :option:`-tiley` options (this can work, but may force tile recompression)
 
 There are several advantages to using the "precompressed" feature for formats that support it:
 
@@ -38,3 +43,8 @@ Formats that support precompressed tile writing:
 * DICOM (since 7.1.0)
 * TIFF (forthcoming: https://github.com/ome/bioformats/pull/4190)
 * OME-TIFF (forthcoming: https://github.com/ome/bioformats/pull/4190)
+
+For additional discussion of the "precompressed" tiles feature, see:
+
+* https://forum.image.sc/t/vsi-to-dcm-file-conversion/98249/5
+* https://forum.image.sc/t/exporting-a-dicom-stack/99400

--- a/sphinx/users/comlinetools/precompressed.rst
+++ b/sphinx/users/comlinetools/precompressed.rst
@@ -17,8 +17,8 @@ This feature is primarily exposed in the :program:`bfconvert` command, using the
 When the `-precompressed` option is used, best results are obtained by:
 
 * using the `-noflat` option
-* _not_ using the `-compression` option (this can work, but may force tile recompression)
-* _not_ using the `-tilex` or `-tiley` options (this can work, but may force tile recompression)
+* **not** using the `-compression` option (this can work, but may force tile recompression)
+* **not** using the `-tilex` or `-tiley` options (this can work, but may force tile recompression)
 
 There are several advantages to using the "precompressed" feature for formats that support it:
 
@@ -31,22 +31,29 @@ There are also a few disadvantages:
 * tile sizes cannot be changed during conversion
 * compression type cannot be changed during conversion
 * input and output format must support same compression type and tile size
-* not all formats supported by Bio-Formats currently allow reading/writing precompressed tiles
-* tools other than :program:`bfconvert` do not currently make use of the precompressed tile API
-
-Formats that support precompressed tile reading:
-
-* SVS (since 7.1.0)
-* NDPI (forthcoming: https://github.com/ome/bioformats/pull/4181)
-* DICOM (forthcoming: https://github.com/ome/bioformats/pull/4190)
-
-Formats that support precompressed tile writing:
-
-* DICOM (since 7.1.0)
-* TIFF (forthcoming: https://github.com/ome/bioformats/pull/4190)
-* OME-TIFF (forthcoming: https://github.com/ome/bioformats/pull/4190)
+* the input format must have precompressed tile reading support (see :ref:`readers`)
+* the output format must have precompressed tile writing support (see :ref:`writers`)
+* command-line tools other than :program:`bfconvert` do not currently make use of the precompressed tile API
 
 For additional discussion of the "precompressed" tiles feature, see:
 
 * https://forum.image.sc/t/vsi-to-dcm-file-conversion/98249/5
 * https://forum.image.sc/t/exporting-a-dicom-stack/99400
+
+.. _readers:
+
+Formats that support precompressed tile reading
+-----------------------------------------------
+
+* SVS (since 7.1.0)
+* NDPI (forthcoming: https://github.com/ome/bioformats/pull/4181)
+* DICOM (forthcoming: https://github.com/ome/bioformats/pull/4190)
+
+.. _writers:
+
+Formats that support precompressed tile writing
+-----------------------------------------------
+
+* DICOM (since 7.1.0)
+* TIFF (forthcoming: https://github.com/ome/bioformats/pull/4190)
+* OME-TIFF (forthcoming: https://github.com/ome/bioformats/pull/4190)

--- a/sphinx/users/comlinetools/precompressed.rst
+++ b/sphinx/users/comlinetools/precompressed.rst
@@ -1,7 +1,7 @@
 "Precompressed" tiles
 =====================
 
-See first :doc:`a summary of the precompressed tiles feature </formats/precompressed>`.
+See first :doc:`an overview of what precompressed tiles are and which formats support them </formats/precompressed>`.
 
 This feature is primarily exposed in the :program:`bfconvert` command, using the `-precompressed` option.
 When the `-precompressed` option is used, best results are obtained by:

--- a/sphinx/users/comlinetools/precompressed.rst
+++ b/sphinx/users/comlinetools/precompressed.rst
@@ -1,0 +1,40 @@
+"Precompressed" tiles
+=====================
+
+Some formats allow reading and/or writing "precompressed" tiles.
+This feature is primarily intended for whole slide images, each of which may have thousands of tiles.
+
+When reading, this allows for retrieving compressed bytes that are as close as possible
+to what is actually stored in the file. Decompression (if necessary) is the responsibility
+of the consumer.
+
+When writing, compressed bytes instead of raw bytes can be provided to the writer,
+such that the writer will just save the provided compressed bytes instead of recompressing.
+
+This feature is primarily exposed in the :program:`bfconvert` command, using the :option:`-precompressed` option.
+
+There are several advantages to using the "precompressed" feature for formats that support it:
+
+* faster tile read and write times, as no tile compression/decompression needs to be performed
+* no change in compression quality
+* very little change in file sizes between input and output data
+
+There are also a few disadvantages:
+
+* tile sizes cannot be changed during conversion
+* compression type cannot be changed during conversion
+* input and output format must support same compression type and tile size
+* not all formats supported by Bio-Formats currently allow reading/writing precompressed tiles
+* tools other than :program:`bfconvert` do not currently make use of the precompressed tile API
+
+Formats that support precompressed tile reading:
+
+* SVS (since 7.1.0)
+* NDPI (forthcoming: https://github.com/ome/bioformats/pull/4181)
+* DICOM (forthcoming: https://github.com/ome/bioformats/pull/4190)
+
+Formats that support precompressed tile writing:
+
+* DICOM (since 7.1.0)
+* TIFF (forthcoming: https://github.com/ome/bioformats/pull/4190)
+* OME-TIFF (forthcoming: https://github.com/ome/bioformats/pull/4190)

--- a/sphinx/users/comlinetools/precompressed.rst
+++ b/sphinx/users/comlinetools/precompressed.rst
@@ -13,12 +13,12 @@ of the consumer.
 When writing, compressed bytes instead of raw bytes can be provided to the writer,
 such that the writer will just save the provided compressed bytes instead of recompressing.
 
-This feature is primarily exposed in the :program:`bfconvert` command, using the :option:`-precompressed` option.
-When the :option:`-precompressed` option is used, best results are obtained by:
+This feature is primarily exposed in the :program:`bfconvert` command, using the `-precompressed` option.
+When the `-precompressed` option is used, best results are obtained by:
 
-* using the :option:`-noflat` option
-* _not_ using the :option:`-compression` option (this can work, but may force tile recompression)
-* _not_ using the :option:`-tilex` or :option:`-tiley` options (this can work, but may force tile recompression)
+* using the `-noflat` option
+* _not_ using the `-compression` option (this can work, but may force tile recompression)
+* _not_ using the `-tilex` or `-tiley` options (this can work, but may force tile recompression)
 
 There are several advantages to using the "precompressed" feature for formats that support it:
 

--- a/sphinx/users/comlinetools/precompressed.rst
+++ b/sphinx/users/comlinetools/precompressed.rst
@@ -1,17 +1,7 @@
 "Precompressed" tiles
 =====================
 
-Some formats allow reading and/or writing "precompressed" tiles.
-This feature is primarily intended for whole slide images, each of which may have thousands of tiles.
-Data representing these tiles may be compressed, either lossily or losslessly, depending on the
-file format, imaging modality, or acquisition configuration.
-
-When reading, this allows for retrieving compressed bytes that are as close as possible
-to what is actually stored in the file. Decompression (if necessary) is the responsibility
-of the consumer.
-
-When writing, compressed bytes instead of raw bytes can be provided to the writer,
-such that the writer will just save the provided compressed bytes instead of recompressing.
+See first :doc:`a summary of the precompressed tiles feature </formats/precompressed>`.
 
 This feature is primarily exposed in the :program:`bfconvert` command, using the `-precompressed` option.
 When the `-precompressed` option is used, best results are obtained by:
@@ -20,7 +10,7 @@ When the `-precompressed` option is used, best results are obtained by:
 * **not** using the `-compression` option (this can work, but may force tile recompression)
 * **not** using the `-tilex` or `-tiley` options (this can work, but may force tile recompression)
 
-There are several advantages to using the "precompressed" feature for formats that support it:
+There are several advantages to converting using the "precompressed" feature for formats that support it:
 
 * faster tile read and write times, as no tile compression/decompression needs to be performed
 * no change in compression quality
@@ -31,29 +21,11 @@ There are also a few disadvantages:
 * tile sizes cannot be changed during conversion
 * compression type cannot be changed during conversion
 * input and output format must support same compression type and tile size
-* the input format must have precompressed tile reading support (see :ref:`readers`)
-* the output format must have precompressed tile writing support (see :ref:`writers`)
+* the input format must have precompressed tile reading support (see :ref:`the list of supported readers <precompressed#readers>`)
+* the output format must have precompressed tile writing support (see :ref:`the list of supported writers <precompressed#writers>`)
 * command-line tools other than :program:`bfconvert` do not currently make use of the precompressed tile API
 
 For additional discussion of the "precompressed" tiles feature, see:
 
 * https://forum.image.sc/t/vsi-to-dcm-file-conversion/98249/5
 * https://forum.image.sc/t/exporting-a-dicom-stack/99400
-
-.. _readers:
-
-Formats that support precompressed tile reading
------------------------------------------------
-
-* SVS (since 7.1.0)
-* NDPI (forthcoming: https://github.com/ome/bioformats/pull/4181)
-* DICOM (forthcoming: https://github.com/ome/bioformats/pull/4190)
-
-.. _writers:
-
-Formats that support precompressed tile writing
------------------------------------------------
-
-* DICOM (since 7.1.0)
-* TIFF (forthcoming: https://github.com/ome/bioformats/pull/4190)
-* OME-TIFF (forthcoming: https://github.com/ome/bioformats/pull/4190)

--- a/sphinx/users/index.rst
+++ b/sphinx/users/index.rst
@@ -35,6 +35,7 @@ for carrying out a variety of tasks:
     :includehidden:
 
     comlinetools/index
+    comlinetools/precompressed
 
 .. seealso::
    :doc:`/formats/options`


### PR DESCRIPTION
See https://github.com/ome/bioformats/pull/4190#pullrequestreview-2238703479. This is mostly for users of bfconvert at the moment; a next step (here or in a new PR) would be something more useful to developers.