### PR TITLE
Migrate the command-line tools index to the users page

### DIFF
--- a/sphinx/users/comlinetools/index.rst
+++ b/sphinx/users/comlinetools/index.rst
@@ -1,22 +1,7 @@
-Command line tools
-==================
+Command line tools overview
+===========================
 
 There are several scripts for using Bio-Formats on the command line.
-
-.. toctree::
-    :maxdepth: 1
-    :titlesonly:
-    :hidden:
-
-    display
-    conversion
-    xml-validation
-    edit
-    domainlist
-    formatlist
-    ijview
-    xmlindent
-    mkfake
 
 Installation
 ------------

--- a/sphinx/users/index.rst
+++ b/sphinx/users/index.rst
@@ -35,6 +35,15 @@ for carrying out a variety of tasks:
     :includehidden:
 
     comlinetools/index
+    comlinetools/display
+    comlinetools/conversion
+    comlinetools/xml-validation
+    comlinetools/edit
+    comlinetools/domainlist
+    comlinetools/formatlist
+    comlinetools/ijview
+    comlinetools/xmlindent
+    comlinetools/mkfake
 
 .. seealso::
    :doc:`/formats/options`


### PR DESCRIPTION
Motivated by the review of https://github.com/ome/bio-formats-documentation/pull/390 and the upcoming addition of new pages to the command-line tools section of the user documentation

Also rename the comlinetools/index page as overview for clarity This should unify the layout of the command-line-tools section with the other sections of the user documentations without breaking the navigability

When using the left-hand panel navigation, this should also get rid of the nested Command line tools > Command line tools menu and remove the sub-section of the overview from the navigation