### PR TITLE
Set Sphinx as requirement in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,6 @@
 channels:
   - conda-forge
 dependencies:
+  - python<3.13
   - maven
   - sphinx-rtd-theme


### PR DESCRIPTION
This tries to resolve the build issues raised in https://github.com/ome/bio-formats-documentation/pull/395.

The version of Sphinx installed in the current readthedocs build infrastructure (5.3.0) is incompatible with the Python 3.13 released this week (due to module removal). This tries to workaround the issue by forcing Python< 3.13 which has been working for last months.

Eventually, this infrastructure should be reviewed to install modern versions of Sphinx but this is beyond the scope of this PR which aims to get the builds passing again
