### PR TITLE
Fake channel wavelength keys

### DIFF
--- a/sphinx/developers/generating-test-images.rst
+++ b/sphinx/developers/generating-test-images.rst
@@ -59,6 +59,9 @@ exposure times and positions to be set for each plane:
 ::
 
     echo "[series_0]" >> my-special-test-file.fake.ini
+    echo "ChannelEmissionWavelength_0=461nm" >> my-special-test-file.fake.ini
+    echo "ChannelExcitationWavelength_0=358nm" >> my-special-test-file.fake.ini
+    echo "ExposureTimeUnit_0=ms" >> my-special-test-file.fake.ini
     echo "ExposureTime_0=10" >> my-special-test-file.fake.ini
     echo "ExposureTimeUnit_0=ms" >> my-special-test-file.fake.ini
     echo "PositionX_0=5" >> my-special-test-file.fake.ini
@@ -265,9 +268,6 @@ with their default values, is shown below.
     - * physicalSizeZ
       * real depth of the pixels, supports units defaulting to microns
       *
-    - * ChannelName_x
-      * the channel name for channel x
-      *
     - * color
       * the default color for all channels [3]_
       * null
@@ -276,6 +276,27 @@ with their default values, is shown below.
       *
     - * ellipses, labels, lines, points, polygons, polylines, rectangles
       * the number of ROIs containing one shape of the given type to generate
+      *
+    - * emission_x
+      * the emission wavelength for channel ``x``, supports units defaulting to nanometers [2]_
+      *
+    - * excitation_x
+      * the excitation wavelength for channel ``x``, supports units defaulting to nanometers [2]_
+      *
+    - * ChannelEmissionWavelength_x
+      * the emission wavelength for channel ``x``, supports units defaulting to nanometers [2]_
+      *
+    - * ChannelExcitationWavelength_x
+      * the excitation wavelength for channel ``x``, supports units defaulting to nanometers [2]_
+      *
+    - * ChannelName_x
+      * the channel name for channel ``x`` [2]_
+      *
+    - * DeltaT_x
+      * time since the beginning of the acquisition for plane ``x`` [2]_
+      *
+    - * DeltaTUnit_x
+      * string defining the units for the corresponding ``DeltaT_x`` [2]_
       *
     - * ExposureTime_x
       * floating point exposure time for plane ``x`` [2]_

--- a/sphinx/developers/generating-test-images.rst
+++ b/sphinx/developers/generating-test-images.rst
@@ -253,6 +253,9 @@ with their default values, is shown below.
     - * fields
       * number of fields per well
       * 0 [1]_
+    - * withInstrument
+      * whether or not a populated instrument should be added to the metadata
+      * false
     - * withMicrobeam
       * whether or not a microbeam should be added to the experiment (HCS only)
       * false

--- a/sphinx/developers/generating-test-images.rst
+++ b/sphinx/developers/generating-test-images.rst
@@ -281,10 +281,10 @@ with their default values, is shown below.
       * the number of ROIs containing one shape of the given type to generate
       *
     - * emission_x
-      * the emission wavelength for channel ``x``, supports units defaulting to nanometers [2]_
+      * the emission wavelength for channel ``x``, supports units defaulting to nanometers
       *
     - * excitation_x
-      * the excitation wavelength for channel ``x``, supports units defaulting to nanometers [2]_
+      * the excitation wavelength for channel ``x``, supports units defaulting to nanometers
       *
     - * ChannelEmissionWavelength_x
       * the emission wavelength for channel ``x``, supports units defaulting to nanometers [2]_
@@ -300,7 +300,7 @@ with their default values, is shown below.
       *
     - * DeltaTUnit_x
       * string defining the units for the corresponding ``DeltaT_x`` [2]_
-      *
+      * seconds
     - * ExposureTime_x
       * floating point exposure time for plane ``x`` [2]_
       *


### PR DESCRIPTION
Depends on https://github.com/ome/bioformats/pull/4272

This documents the new set of keys added to `FakeReader` allowing to configure channel emission and excitation wavelength as per well as populating an instrument in the metadata