### PR TITLE
Link to Farsight GitHub instead of wiki

### DIFF
--- a/sphinx/users/farsight/index.rst
+++ b/sphinx/users/farsight/index.rst
@@ -1,7 +1,7 @@
 FARSIGHT
 ========
 
-`FARSIGHT <http://farsight-toolkit.ee.uh.edu/wiki/Main_Page>`_ is a collection of
+`FARSIGHT <https://github.com/RoysamLab/Farsight-toolkit>`_ is a collection of
 modules for image analysis created by LOCI's collaborators at the
 `University of Houston <http://www.uh.edu/>`_. These
 open source modules are built on the :doc:`/users/itk/index` library
@@ -9,11 +9,6 @@ and thus can take advantage of ITK's support for Bio-Formats to process
 otherwise unsupported image formats.
 
 The principal FARSIGHT module that benefits from Bio-Formats is the
-`Nucleus Editor <http://farsight-toolkit.ee.uh.edu/wiki/NucleusEditor>`_,
+`Nucleus Editor <https://github.com/RoysamLab/Farsight-toolkit/tree/master/NuclearSegmentation/NucleusEditor>`_,
 though in principle any FARSIGHT-based code that reads image formats via
 the standard ITK mechanism will be able to leverage Bio-Formats.
-
-.. seealso::
-    `FARSIGHT Downloads page <http://farsight-toolkit.ee.uh.edu/wiki/Special:FarsightDownloads>`_
-
-    `FARSIGHT HowToBuild tutorial <http://farsight-toolkit.ee.uh.edu/wiki/FARSIGHT_HowToBuild>`_

--- a/sphinx/users/vaa3d/index.rst
+++ b/sphinx/users/vaa3d/index.rst
@@ -7,6 +7,4 @@ Janelia Farm Research Campus <http://www.hhmi.org/programs/biomedical-research/j
 handy, fast, and versatile 3D/4D/5D Image Visualization & Analysis
 System for Bioimages & Surface Objects.
 
-Vaa3D can use Bio-Formats via the `Bio-Formats C++
-bindings <http://farsight-toolkit.ee.uh.edu/wiki/FARSIGHT_Tutorials/Building_Software/Bio-Formats/Building_C%2B%2B_Bindings>`_
-to read images.
+Vaa3D can use Bio-Formats via the Bio-Formats C++ bindings to read images.


### PR DESCRIPTION
At the time of this commit, the wiki has been entirely removed, and `farsight-toolkit.org` no longer refers to the Farsight project.

The [linkcheck](https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/338/) build has been failing for a few days, so this should hopefully fix the build.

I'm of multiple minds on the best approach here - on one hand, it's possible the wiki is just down for maintenance, and will come back at some point or be moved somewhere else. On the other hand, no updates to the GitHub repo in over a decade and no other usable web presence suggests that Farsight should be removed entirely from Bio-Formats documentation. I opted for just changing links to get the build passing, but happy to hear other thoughts. This ties in a bit with the discussion of #247, @sbesson / @joshmoore / @jburel.