### PR TITLE
Update SVS format page to reference options page

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -237,6 +237,7 @@ privateSpecification = true
 pyramid = yes
 reader = SVSReader
 mif = true
+options = true
 notes = .. seealso:: \n
   `Aperio ImageScope <https://www.leicabiosystems.com/digital-pathology/manage/aperio-imagescope/>`_
 


### PR DESCRIPTION
This is for the recent `svs.remove_thumbnail` option, which is already described on https://bio-formats.readthedocs.io/en/latest/formats/options.html.