### PR TITLE
Delete ionpath, ignore princeton

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -396,5 +396,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://www.microsoft.com/en-us/download/details.aspx?id=48145', # 403 Client Error: Forbidden
     r'https://www.agilent.com/home', # 403 Client Error: Forbidden
     r'https://mathworks.com/.*', # 403 Client Error: Forbidden
-    r'https://uk.mathworks.com/.*' # 403 Client Error: Forbidden
+    r'https://uk.mathworks.com/.*', # 403 Client Error: Forbidden
+    r'https://www.princetoninstruments.com/.*' # 403 Client Error: Forbidden
 ]

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -1133,8 +1133,8 @@ mif = true
 
 [Ionpath MIBI]
 extensions = .tif, .tiff
-owner = `IonPath <https://www.ionpath.com/>`_
-developer = `IonPath <https://www.ionpath.com/>`_
+owner = `IonPath`
+developer = `IonPath`
 versions = 0.1
 bsd = no
 weHave = * a few sample datasets\n


### PR DESCRIPTION
1. Delete ionpath links, as ``Company no longer exist`` message is on https://www.ionpath.com/
2. Ignore ``...princeton....`` as link works, but probably linkchecker is not coming through