### PR TITLE
Fix two more broken links

### DIFF
--- a/sphinx/developers/commit-testing.rst
+++ b/sphinx/developers/commit-testing.rst
@@ -9,7 +9,7 @@ contains the infrastructure to run automated tests against reference data.
 These tests check the metadata and binary data of every dataset using
 INI-based configuration files as the source of truth.
 
-All representative files submitted as part of the `bug report <bug-reporting>`_
+All representative files submitted as part of the :doc:`bug report </about/bug-reporting>`_
 or development projects and used as supporting data for new Bio-Formats releases
 are stored in a curated QA repository, also known as the full data repository,
 managed by the Bio-Formats maintainers alongside the associated configuration

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -1706,7 +1706,7 @@ notes = Commercial applications that support MRC include: \n
 * `Bitplane Imaris <http://www.bitplane.com/>`_ \n
 \n
 Bio-Formats provides support for the base MRC2000/MRC2014 specifications. Limited support is provided for vendor-specific \n
-extended headers, as described in the `MRC2014 specification <https://www.ccpem.ac.uk/mrc_format/mrc2014.php#note8>`_. \n
+extended headers, as described in the `MRC2014 specification <https://www.ccpem.ac.uk/mrc_format/mrc2014.php#8>`_. \n
 `IMOD <https://bio3d.colorado.edu/imod/doc/mrc_format.txt>`_ extended metadata is perhaps the best-supported variant. \n
 \n
 .. seealso:: \n


### PR DESCRIPTION
Both flagged by https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/360/. Together with #414, this is expected to fix the linkcheck build.