### PR TITLE
Exclude merckmillipore.com from link check

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -398,5 +398,5 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://mathworks.com/.*', # 403 Client Error: Forbidden
     r'https://uk.mathworks.com/.*', # 403 Client Error: Forbidden
     r'https://www.princetoninstruments.com/.*', # 403 Client Error: Forbidden
-    r'https://www.merckmillipore.com/.*' # 403 Client Error: Forbidden
+    r'https://www.merckmillipore.com*' # 403 Client Error: Forbidden
 ]

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -397,5 +397,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://www.agilent.com/home', # 403 Client Error: Forbidden
     r'https://mathworks.com/.*', # 403 Client Error: Forbidden
     r'https://uk.mathworks.com/.*', # 403 Client Error: Forbidden
-    r'https://www.princetoninstruments.com/.*' # 403 Client Error: Forbidden
+    r'https://www.princetoninstruments.com/.*', # 403 Client Error: Forbidden
+    r'https://www.merckmillipore.com/.*' # 403 Client Error: Forbidden
 ]


### PR DESCRIPTION
Since a few days the URL check for https://www.merckmillipore.com is failing with 403, but works manually in the browser. This PR just adds it to the exclude list for the link check.

```
(formats/amnis-flowsight: line   10) broken    https://www.merckmillipore.com/ - 403 Client Error: Forbidden for url: https://www.merckmillipore.com/
```
( https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/421/console )