### PR TITLE
Replace link to Vaa3D for a relevant one and fix peng lab link

### DIFF
--- a/sphinx/users/vaa3d/index.rst
+++ b/sphinx/users/vaa3d/index.rst
@@ -2,7 +2,7 @@ Vaa3D
 =====
 
 `Vaa3D <https://www.janelia.org/publication/vaa3d-enables-real-time-3d-visualization-and-quantitative-analysis-large-scale>`_,
-developed by the `Peng Lab <https://www.janelia.org/peng-lab>`_ at the `HHMI
+developed by the `Peng Lab <https://home.penglab.com/proj/vaa3d/home/index.html>`_ at the `HHMI
 Janelia Farm Research Campus <http://www.hhmi.org/programs/biomedical-research/janelia-research-campus>`_, is a
 handy, fast, and versatile 3D/4D/5D Image Visualization & Analysis
 System for Bioimages & Surface Objects.

--- a/sphinx/users/vaa3d/index.rst
+++ b/sphinx/users/vaa3d/index.rst
@@ -1,8 +1,8 @@
 Vaa3D
 =====
 
-`Vaa3D <https://alleninstitute.org/what-we-do/brain-science/research/products-tools/vaa3d/>`_,
-developed by the `Peng Lab <http://home.penglab.com/>`_ at the `HHMI
+`Vaa3D <https://www.janelia.org/publication/vaa3d-enables-real-time-3d-visualization-and-quantitative-analysis-large-scale>`_,
+developed by the `Peng Lab <https://www.janelia.org/peng-lab>`_ at the `HHMI
 Janelia Farm Research Campus <http://www.hhmi.org/programs/biomedical-research/janelia-research-campus>`_, is a
 handy, fast, and versatile 3D/4D/5D Image Visualization & Analysis
 System for Bioimages & Surface Objects.


### PR DESCRIPTION
Replacing 2 links to fix build jenkins.

1. The Peng Lab link was broken and it seems that the chance of it being live again are slim (restructuring of the janelia pages imho)
2. The Vaa3D link just above it was being redirected to a generic page with no Vaa3D mention. Replaced it with a link to the Vaa3D publication.
