### PR TITLE
Fix limited javadoc syntax

### DIFF
--- a/sphinx/developers/file-reader.rst
+++ b/sphinx/developers/file-reader.rst
@@ -85,7 +85,7 @@ from the OME-XML Metadata. These fields can be accessed in a similar way to the 
 An example of such values would be the physical size of dimensions X, Y and Z. The accessor methods 
 for these properties return a :xml_javadoc:`Length <ome/units/quantity/Length.html>` object which 
 contains both the value and unit of the dimension. These lengths can also be converted to other units using 
-:xml_javadoc:`value(ome.units.unit.Unit) <ome/units/quantity/Length.html#value-ome.units.unit.Unit->`
+:xml_javadoc:`value(ome.units.unit.Unit) <ome/units/quantity/Length.html#value(ome.units.unit.Unit)>`
 An example of reading and converting these physical sizes values can be found in 
 :download:`ReadPhysicalSize.java <examples/ReadPhysicalSize.java>`.
 

--- a/sphinx/developers/in-memory.rst
+++ b/sphinx/developers/in-memory.rst
@@ -4,7 +4,7 @@ In-memory reading and writing in Bio-Formats
 Bio-Formats readers and writers are traditionally used to handle image files 
 from disk. However it is also possible to achieve reading and writing of files from 
 in-memory sources. This is handled by mapping the in-memory data to a file location using :common_javadoc:`Location.mapFile() 
-<loci/common/Location.html#mapFile-java.lang.String-loci.common.IRandomAccess->`.
+<loci/common/Location.html#mapFile(java.lang.String,loci.common.IRandomAccess)>`.
 
 ::
 

--- a/sphinx/developers/reader-guide.rst
+++ b/sphinx/developers/reader-guide.rst
@@ -144,8 +144,8 @@ Thus, a stub for ``initFile(String)`` might look like this:
 
 
 For more details, see
-:common_javadoc:`loci.common.Location.mapId(java.lang.String, java.lang.String) <loci/common/Location.html#mapId-java.lang.String-java.lang.String->`
-and :common_javadoc:`loci.common.Location.getMappedId(java.lang.String) <loci/common/Location.html#getMappedId-java.lang.String->`.
+:common_javadoc:`loci.common.Location.mapId(java.lang.String, java.lang.String) <loci/common/Location.html#mapId(java.lang.String,java.lang.String)>`
+and :common_javadoc:`loci.common.Location.getMappedId(java.lang.String) <loci/common/Location.html#getMappedId(java.lang.String)>`.
 
 Variables to populate
 ---------------------


### PR DESCRIPTION
Transferring only the

1. ``xml_javadoc``
2. ``common_javadoc``

changes from https://github.com/ome/bio-formats-documentation/pull/429 as per @melissalinkert comment https://github.com/ome/bio-formats-documentation/pull/429#issuecomment-3108927414