### PR TITLE
Add format page for Zeiss XRM format

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -2834,3 +2834,18 @@ Commercial applications that support this format include: \n
 * `Bitplane Imaris <http://www.bitplane.com/>`_ \n
 * `Amira <https://www.fei.com/software/amira-avizo/>`_ \n
 * `Image-Pro Plus <http://www.mediacy.com/>`_
+
+[Zeiss XRM]
+pagename = zeiss-xrm
+extensions = .txm, .txrm
+owner = `ZEISS International <https://www.zeiss.com>`_
+bsd = no
+software = ZEN Data Explorer
+weHave = * a few sample datasets
+pixelsRating = Outstanding
+metadataRating = Very good
+opennessRating = Good
+presenceRating = Good
+utilityRating = Good
+reader = ZeissXRMReader
+mif = false

--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -2839,8 +2839,9 @@ Commercial applications that support this format include: \n
 pagename = zeiss-xrm
 extensions = .txm, .txrm
 owner = `ZEISS International <https://www.zeiss.com>`_
+developer = ZEISS X-Ray Microscopy division
 bsd = no
-software = ZEN Data Explorer
+software = XRM Data Explorer
 weHave = * a few sample datasets
 pixelsRating = Outstanding
 metadataRating = Very good


### PR DESCRIPTION
Following the release of the 8.3.0 components, the `ZeissXRMReader` metadata page should be generated and cross-linked.
Up for review as always are the format ratings as well as the various informations about the reference software and test datasets