### PR TITLE
Replace nikoninstruments link with redirect

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -1792,7 +1792,7 @@ reader = NikonTiffReader
 extensions = .nd2
 developer = `Nikon USA <https://www.nikonusa.com/en/index.page>`_
 bsd = no
-software = `NIS-Elements Viewer from Nikon <https://www.nikoninstruments.com/Products/Software/NIS-Elements-Advanced-Research/NIS-Elements-Viewer>`_
+software = `NIS-Elements Viewer from Nikon <https://www.microscope.healthcare.nikon.com/products/software/nis-elements/nis-elements-advanced-research>`_
 weHave = * many ND2 datasets\n
 * `public sample images <https://downloads.openmicroscopy.org/images/ND2/>`__
 weWant = * an official specification document


### PR DESCRIPTION
As can be seen on https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/534/console - the redirect was in place back then, but then it was probably removed, as since 02 August (almost 2 weeks now) the old link is not working. 

cc @melissalinkert @will-moore 