### PR TITLE
Replace broken link in lemkesoft with working one

### DIFF
--- a/sphinx/users/graphic-con/index.rst
+++ b/sphinx/users/graphic-con/index.rst
@@ -1,7 +1,7 @@
 Graphic Converter
 =================
 
-`Graphic Converter <https://www.lemkesoft.de/en/translate-to-english-mac-fotobearbeitung-mac-diashow-mac-grafikprogramm-mac-bildbetrachter>`_ is a Mac OS application
+`Graphic Converter <https://www.lemkesoft.de/en/products/graphicconverter>`_ is a Mac OS application
 for opening, editing, and organizing photos. Versions 6.4.1 and later
 use Bio-Formats to open all file formats supported by Bio-Formats.
 

--- a/sphinx/users/graphic-con/index.rst
+++ b/sphinx/users/graphic-con/index.rst
@@ -1,7 +1,7 @@
 Graphic Converter
 =================
 
-`Graphic Converter <https://www.lemkesoft.de/en/image-editing-slideshow-browser-batch-conversion-metadata-and-more-on-your-mac/>`_ is a Mac OS application
+`Graphic Converter <https://www.lemkesoft.de/en/translate-to-english-mac-fotobearbeitung-mac-diashow-mac-grafikprogramm-mac-bildbetrachter>`_ is a Mac OS application
 for opening, editing, and organizing photos. Versions 6.4.1 and later
 use Bio-Formats to open all file formats supported by Bio-Formats.
 


### PR DESCRIPTION
The https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/550/console is already second build where the original link fixed here is broken (and confirmed as broken manually). Imho, the link was silently replaced by the one which I am suggesting in this PR: got the new link simply by searching (with english terms) on lemkesoft page.