### PR TITLE
Exclude https://www.mail-archive.com/tiff from linkcheck

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -398,5 +398,5 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://uk.mathworks.com/.*', # 403 Client Error: Forbidden
     r'https://www.princetoninstruments.com/.*', # 403 Client Error: Forbidden
     r'https://www.merckmillipore.com*', # 403 Client Error: Forbidden
-    r'https://www.mail-archive.com/.*' # Connection to www.mail-archive.com often times out
+    r'https://www.mail-archive.com*' # Connection to www.mail-archive.com often times out
 ]


### PR DESCRIPTION
Exclude https://www.mail-archive.com/tiff@lists.osgeo.org/msg00421.html from linkcheck, as it often times out.
