### PR TITLE
Link to Receipt of Sample Data

### DIFF
--- a/sphinx/about/bug-reporting.rst
+++ b/sphinx/about/bug-reporting.rst
@@ -76,7 +76,7 @@ the following information:
    relevant windows.
 -  **Version information**. Indicate which release of Bio-Formats, which
    operating system, and which version of Java you are using.
--  **Non-working data**. If possible, please send a non-working file.
+-  **Non-working data**. If possible, please send a non-working file that may be made public under a liberal license, at least `CC-BY 4.0 <https://creativecommons.org/licenses/by/4.0/>`_.
    This helps us ensure that the problem is fixed for next release and
    will not reappear in later releases. Providing data that cannot be
    made public is strongly discouraged. See `Receipt of Sample Data


### PR DESCRIPTION
As I understand it, policy that we are happy to take "private" data has changed. Text updated accordingly and replaced with a useful link.