### PR TITLE
Add labelPlanes to the list of flags for fake images

### DIFF
--- a/sphinx/developers/generating-test-images.rst
+++ b/sphinx/developers/generating-test-images.rst
@@ -338,6 +338,9 @@ with their default values, is shown below.
     - * sleepInitFile
       * number of milliseconds to sleep for when initFile is called 
       * 0
+    - * labelPlanes
+      * add human-readable labels to the individual planes
+      * false
 
 .. [1] Default value set to 1 if any of the ``screens``, ``plates``,
        ``plateAcqs``, ``plateRows``, ``plateCols`` or ``fields`` values is set


### PR DESCRIPTION
Introduced in https://github.com/ome/bioformats/pull/4339 (scheduled for release in Bio-Formats 8.4.0), I noticed during https://github.com/ome/bioformats/pull/4382#pullrequestreview-3493024367 that we had not documented this new option in the documentation page