### PR TITLE
Replace velocity dependency by velocity-engine-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,8 +98,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.velocity</groupId>
-      <artifactId>velocity</artifactId>
-      <version>1.6.4</version>
+      <artifactId>velocity-engine-core</artifactId>
+      <version>2.4.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
There has been no new releases of the org.apache.velocity:velocity dependency since version 1.7. It looks like the templating engine is now released as org.apache.velocity:velocity-engine-core.