### PR TITLE
Ignore zenodo 403

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -399,5 +399,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://www.princetoninstruments.com/.*', # 403 Client Error: Forbidden
     r'https://www.merckmillipore.com*', # 403 Client Error: Forbidden
     r'https://www.mail-archive.com*', # Connection to www.mail-archive.com often times out
-    r'https://www.hitachi-hightech.com/file/us/pdf/library/technical/Hitachi_4800_STEM.pdf' # 403 Client Error: Forbidden
+    r'https://www.hitachi-hightech.com/file/us/pdf/library/technical/Hitachi_4800_STEM.pdf', # 403 Client Error: Forbidden
+    r'https://zenodo.org*' # 403 Client Error: Forbidden
 ]


### PR DESCRIPTION
The two zenodo links are giving 403, but every manual test is always showing them as working, see

https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/102/consoleFull


cc @melissalinkert @will-moore 