### PR TITLE
Ignore umassmed.edu, 403

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -400,5 +400,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://www.merckmillipore.com*', # 403 Client Error: Forbidden
     r'https://www.mail-archive.com*', # Connection to www.mail-archive.com often times out
     r'https://www.hitachi-hightech.com/file/us/pdf/library/technical/Hitachi_4800_STEM.pdf', # 403 Client Error: Forbidden
-    r'https://zenodo.org*' # 403 Client Error: Forbidden
+    r'https://zenodo.org*', # 403 Client Error: Forbidden
+    r'https://www.umassmed.edu*' # 403 Client Error: Forbidden
 ]


### PR DESCRIPTION
Ignoring link to https://www.umassmed.edu/ which is 403ing since last week.

