### PR TITLE
Require Java 11 at runtime, build on Java 21

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,7 +18,7 @@ sphinx:
 formats: all
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "mambaforge-22.9"
 

--- a/pom.xml
+++ b/pom.xml
@@ -125,10 +125,10 @@
 	<groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.7.0</version>
-        <!-- Require the Java 8 platform. -->
+        <!-- Require the Java 11 platform. -->
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>11</source>
+          <target>11</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Prerequisite to merging #456. See https://www.openmicroscopy.org/2026/03/24/end-of-java-8-support.html.