### PR TITLE
Update Unidata releases URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -466,7 +466,7 @@
     </repository>
     <repository>
       <id>unidata.releases</id>
-      <url>https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases</url>
+      <url>https://artifacts.unidata.ucar.edu/repository/unidata-releases</url>
       <snapshots><enabled>false</enabled></snapshots>
       </repository>
     <repository>


### PR DESCRIPTION
See https://app.readthedocs.org/projects/bio-formats/builds/32650216/ and other recent failing builds following the inclusion of #468 

The old style URL (`https://artifacts.unidata.ucar.edu/content/repositories/<repository>`) has been deprecated in favor of `https://artifacts.unidata.ucar.edu/repository/<repository>` - see https://docs.unidata.ucar.edu/netcdf-java/current/userguide/using_netcdf_java_artifacts.html. Most of the OME components have already been adjusted accordingly