### PR TITLE
ignore nih.gov

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -401,5 +401,6 @@ linkcheck_ignore = ['https://imspector.mpibpc.mpg.de',
     r'https://www.mail-archive.com*', # Connection to www.mail-archive.com often times out
     r'https://www.hitachi-hightech.com/file/us/pdf/library/technical/Hitachi_4800_STEM.pdf', # 403 Client Error: Forbidden
     r'https://zenodo.org*', # 403 Client Error: Forbidden
-    r'https://www.umassmed.edu*' # 403 Client Error: Forbidden
+    r'https://www.umassmed.edu*', # 403 Client Error: Forbidden
+    r'https://www.nih.gov*' # 403 Client Error: Forbidden
 ]


### PR DESCRIPTION
This should fix: https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/207/ (https://www.nih.gov give 403 in linkcheck, but works manually).
