### PR TITLE
Replace Olympus SIS link

### DIFF
--- a/src/main/resources/format-pages.txt
+++ b/src/main/resources/format-pages.txt
@@ -1948,7 +1948,7 @@ mif = true
 
 [Olympus SIS TIFF]
 extensions = .tiff
-developer = `Olympus <https://www.olympus-sis.com/>`_
+developer = `Evident Scientific (formerly Olympus) <https://evidentscientific.com/>`_
 bsd = no
 weHave = * a few example SIS TIFF files
 pixelsRating = Good


### PR DESCRIPTION
`https://www.olympus-sis.com/` now redirects to `https://evidentscientific.com/` anyway. This is intended to fix the build failure in https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-linkcheck/7/consoleFull.